### PR TITLE
feat: Estimate deployment costs

### DIFF
--- a/packages/splits-sdk/src/client.test.ts
+++ b/packages/splits-sdk/src/client.test.ts
@@ -27,6 +27,7 @@ import {
   CONTROLLER_ADDRESS,
   NEW_CONTROLLER_ADDRESS,
   MOCK_FEE_DATA,
+  DEPLOYMENT_COST_ESTIMATION,
 } from './testing/constants'
 import { MockGraphqlClient } from './testing/mocks/graphql'
 import {
@@ -265,6 +266,8 @@ describe('SplitMain writes', () => {
         distributorFeePercent,
       })
 
+      expect(gasCost).toBeDefined()
+      expect(gasCost).toEqual(DEPLOYMENT_COST_ESTIMATION)
       expect(validateRecipients).toBeCalledWith(recipients)
       expect(validateDistributorFeePercent).toBeCalledWith(
         distributorFeePercent,
@@ -288,6 +291,7 @@ describe('SplitMain writes', () => {
       })
 
       expect(gasCost).toBeDefined()
+      expect(gasCost).toEqual(DEPLOYMENT_COST_ESTIMATION)
       expect(validateRecipients).toBeCalledWith(recipients)
       expect(validateDistributorFeePercent).toBeCalledWith(
         distributorFeePercent,

--- a/packages/splits-sdk/src/errors.ts
+++ b/packages/splits-sdk/src/errors.ts
@@ -82,6 +82,15 @@ export class MissingProviderError extends Error {
   }
 }
 
+export class FailedToEstimateGasError extends Error {
+  name = 'FailedToEstimateGasError'
+
+  constructor(m?: string) {
+    super(m)
+    Object.setPrototypeOf(this, FailedToEstimateGasError.prototype)
+  }
+}
+
 export class MissingSignerError extends Error {
   name = 'MissingSignerError'
 

--- a/packages/splits-sdk/src/testing/constants.ts
+++ b/packages/splits-sdk/src/testing/constants.ts
@@ -11,3 +11,4 @@ export const MOCK_FEE_DATA = {
   maxPriorityFeePerGas: BigNumber.from(1500000000),
 }
 export const GAS_ESTIMATION = BigNumber.from(27938)
+export const DEPLOYMENT_COST_ESTIMATION = BigNumber.from('0x0257ee221cebd4')

--- a/packages/splits-sdk/src/testing/constants.ts
+++ b/packages/splits-sdk/src/testing/constants.ts
@@ -5,3 +5,9 @@ export const NEW_CONTROLLER_ADDRESS = '0xnewController'
 export const SORTED_ADDRESSES = ['0xsorted']
 export const SORTED_ALLOCATIONS = [BigNumber.from(50)]
 export const DISTRIBUTOR_FEE = BigNumber.from(9)
+export const MOCK_FEE_DATA = {
+  gasPrice: BigNumber.from(23610503242),
+  maxFeePerGas: BigNumber.from(46721006484),
+  maxPriorityFeePerGas: BigNumber.from(1500000000),
+}
+export const GAS_ESTIMATION = BigNumber.from(27938)

--- a/packages/splits-sdk/src/testing/mocks/splitMain.ts
+++ b/packages/splits-sdk/src/testing/mocks/splitMain.ts
@@ -1,6 +1,11 @@
 import { Provider } from '@ethersproject/abstract-provider'
 
-import { CONTROLLER_ADDRESS, NEW_CONTROLLER_ADDRESS } from '../constants'
+import {
+  CONTROLLER_ADDRESS,
+  GAS_ESTIMATION,
+  MOCK_FEE_DATA,
+  NEW_CONTROLLER_ADDRESS,
+} from '../constants'
 
 export const writeActions = {
   createSplit: jest.fn().mockReturnValue('create_split_tx'),
@@ -22,6 +27,10 @@ export const writeActions = {
   makeSplitImmutable: jest.fn().mockReturnValue('make_split_immutable_tx'),
 }
 
+export const gasEstimationOptions = {
+  createSplit: jest.fn().mockReturnValue(GAS_ESTIMATION),
+}
+
 export const readActions = {
   getETHBalance: jest.fn(),
   getERC20Balance: jest.fn(),
@@ -29,6 +38,8 @@ export const readActions = {
   getController: jest.fn().mockReturnValue(CONTROLLER_ADDRESS),
   getNewPotentialController: jest.fn().mockReturnValue(NEW_CONTROLLER_ADDRESS),
   getHash: jest.fn(),
+  getFeeData: jest.fn().mockReturnValue(MOCK_FEE_DATA),
+  estimateGas: gasEstimationOptions,
 }
 
 export class MockSplitMain {
@@ -37,6 +48,9 @@ export class MockSplitMain {
     getEvent: (eventName: string) => {
       format: () => string
     }
+  }
+  estimateGas: {
+    createSplit: () => {}
   }
   getETHBalance: jest.Mock
   getERC20Balance: jest.Mock
@@ -63,6 +77,7 @@ export class MockSplitMain {
     this.getController = readActions.getController
     this.getNewPotentialController = readActions.getNewPotentialController
     this.getHash = readActions.getHash
+    this.estimateGas = readActions.estimateGas
   }
 
   connect() {


### PR DESCRIPTION
**Rational**
When building a user interface leveraging the splits sdk, we would like to be able to prompt the user with the estimated gas cost in usd dollar terms before they view it within their signer. This pr adds gas estimation functionality for the create split method.

**Usage**
```js
const estimatedDeploymentPrice = await splitsClient.estimateSplitDeploymentCost({
    recipients,
    distributorFeePercent,
    controller,
});
```
This returns the number of wei a user can expect to spend for a deploy.


**Notes**
I've _attempted_ to keep the coding style of this pr in line with what currently exists in the sdk. Please let me know if you would like me to make any changes / enhancements.
