### PR TITLE
Expose utils

### DIFF
--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -9,7 +9,8 @@
     "./constants": "./dist/constants/index.js",
     "./constants/abi": "./dist/constants/abi/index.js",
     "./errors": "./dist/errors.js",
-    "./types": "./dist/types.js"
+    "./types": "./dist/types.js",
+    "./utils/validation": "./dist/utils/validation.js"
   },
   "typesVersions": {
     "*": {
@@ -24,6 +25,9 @@
       ],
       "types": [
         "./dist/types.d.ts"
+      ],
+      "utils/validation": [
+        "./dist/validation.d.ts"
       ]
     }
   },

--- a/packages/splits-sdk/src/client/liquidSplit.test.ts
+++ b/packages/splits-sdk/src/client/liquidSplit.test.ts
@@ -28,7 +28,7 @@ import * as utils from '../utils'
 import {
   validateAddress,
   validateDistributorFeePercent,
-  validateRecipients,
+  validateSplitRecipients,
 } from '../utils/validation'
 import {
   SORTED_ADDRESSES,
@@ -202,7 +202,7 @@ describe('Liquid split writes', () => {
     })
 
   beforeEach(() => {
-    ;(validateRecipients as jest.Mock).mockClear()
+    ;(validateSplitRecipients as jest.Mock).mockClear()
     ;(validateDistributorFeePercent as jest.Mock).mockClear()
     ;(validateAddress as jest.Mock).mockClear()
     getTransactionEventsSpy.mockClear()
@@ -268,7 +268,7 @@ describe('Liquid split writes', () => {
       expect(event.blockNumber).toEqual(12345)
       expect(liquidSplitAddress).toEqual('0xliquidSplit')
       expect(validateAddress).toBeCalledWith(CONTROLLER_ADDRESS)
-      expect(validateRecipients).toBeCalledWith(
+      expect(validateSplitRecipients).toBeCalledWith(
         recipients,
         LIQUID_SPLITS_MAX_PRECISION_DECIMALS,
       )
@@ -301,7 +301,7 @@ describe('Liquid split writes', () => {
       expect(event.blockNumber).toEqual(12345)
       expect(liquidSplitAddress).toEqual('0xliquidSplit')
       expect(validateAddress).toBeCalledWith('0xowner')
-      expect(validateRecipients).toBeCalledWith(
+      expect(validateSplitRecipients).toBeCalledWith(
         recipients,
         LIQUID_SPLITS_MAX_PRECISION_DECIMALS,
       )

--- a/packages/splits-sdk/src/client/liquidSplit.ts
+++ b/packages/splits-sdk/src/client/liquidSplit.ts
@@ -58,7 +58,7 @@ import {
 import {
   validateAddress,
   validateDistributorFeePercent,
-  validateRecipients,
+  validateSplitRecipients,
 } from '../utils/validation'
 
 type LS1155Abi = typeof ls1155CloneAbi
@@ -88,7 +88,7 @@ class LiquidSplitTransactions extends BaseTransactions {
     owner = undefined,
     transactionOverrides = {},
   }: CreateLiquidSplitConfig): Promise<TransactionFormat> {
-    validateRecipients(recipients, LIQUID_SPLITS_MAX_PRECISION_DECIMALS)
+    validateSplitRecipients(recipients, LIQUID_SPLITS_MAX_PRECISION_DECIMALS)
     validateDistributorFeePercent(distributorFeePercent)
 
     if (this._shouldRequreWalletClient) this._requireWalletClient()

--- a/packages/splits-sdk/src/client/oracle.test.ts
+++ b/packages/splits-sdk/src/client/oracle.test.ts
@@ -44,13 +44,17 @@ describe('Client config validation', () => {
     expect(() => new OracleClient({ chainId: 5 })).not.toThrow()
   })
 
-  test('Polygon chain ids fail', () => {
-    expect(() => new OracleClient({ chainId: 137 })).toThrow()
+  test('Polygon chain id pass', () => {
+    expect(() => new OracleClient({ chainId: 137 })).not.toThrow()
+  })
+  test('Mumbai chain id fail', () => {
     expect(() => new OracleClient({ chainId: 80001 })).toThrow()
   })
 
-  test('Optimism chain ids fail', () => {
-    expect(() => new OracleClient({ chainId: 10 })).toThrow()
+  test('Optimism chain id pass', () => {
+    expect(() => new OracleClient({ chainId: 10 })).not.toThrow()
+  })
+  test('Optimism goerli chain id fail', () => {
     expect(() => new OracleClient({ chainId: 420 })).toThrow()
   })
 
@@ -64,8 +68,8 @@ describe('Client config validation', () => {
     expect(() => new OracleClient({ chainId: 999 })).toThrow()
   })
 
-  test('Base chain ids fail', () => {
-    expect(() => new OracleClient({ chainId: 8453 })).toThrow()
+  test('Base chain ids pass', () => {
+    expect(() => new OracleClient({ chainId: 8453 })).not.toThrow()
   })
 
   test('Other chain ids fail', () => {

--- a/packages/splits-sdk/src/client/passThroughWallet.test.ts
+++ b/packages/splits-sdk/src/client/passThroughWallet.test.ts
@@ -112,13 +112,17 @@ describe('Client config validation', () => {
     expect(() => new PassThroughWalletClient({ chainId: 5 })).not.toThrow()
   })
 
-  test('Polygon chain ids fail', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 137 })).toThrow()
+  test('Polygon chain id pass', () => {
+    expect(() => new PassThroughWalletClient({ chainId: 137 })).not.toThrow()
+  })
+  test('Mumbai chain id fail', () => {
     expect(() => new PassThroughWalletClient({ chainId: 80001 })).toThrow()
   })
 
-  test('Optimism chain ids fail', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 10 })).toThrow()
+  test('Optimism chain id pass', () => {
+    expect(() => new PassThroughWalletClient({ chainId: 10 })).not.toThrow()
+  })
+  test('Optimism goerli chain id fail', () => {
     expect(() => new PassThroughWalletClient({ chainId: 420 })).toThrow()
   })
 
@@ -132,8 +136,8 @@ describe('Client config validation', () => {
     expect(() => new PassThroughWalletClient({ chainId: 999 })).toThrow()
   })
 
-  test('Base chain ids fail', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 8453 })).toThrow()
+  test('Base chain ids pass', () => {
+    expect(() => new PassThroughWalletClient({ chainId: 8453 })).not.toThrow()
   })
 
   test('Other chain ids fail', () => {

--- a/packages/splits-sdk/src/client/swapper.test.ts
+++ b/packages/splits-sdk/src/client/swapper.test.ts
@@ -142,13 +142,17 @@ describe('Client config validation', () => {
     expect(() => new SwapperClient({ chainId: 5 })).not.toThrow()
   })
 
-  test('Polygon chain ids fail', () => {
-    expect(() => new SwapperClient({ chainId: 137 })).toThrow()
+  test('Polygon chain id pass', () => {
+    expect(() => new SwapperClient({ chainId: 137 })).not.toThrow()
+  })
+  test('Mumbai chain id fail', () => {
     expect(() => new SwapperClient({ chainId: 80001 })).toThrow()
   })
 
-  test('Optimism chain ids fail', () => {
-    expect(() => new SwapperClient({ chainId: 10 })).toThrow()
+  test('Optimism chain id pass', () => {
+    expect(() => new SwapperClient({ chainId: 10 })).not.toThrow()
+  })
+  test('Optimism goerli chain id fail', () => {
     expect(() => new SwapperClient({ chainId: 420 })).toThrow()
   })
 
@@ -162,8 +166,8 @@ describe('Client config validation', () => {
     expect(() => new SwapperClient({ chainId: 999 })).toThrow()
   })
 
-  test('Base chain ids fail', () => {
-    expect(() => new SwapperClient({ chainId: 8453 })).toThrow()
+  test('Base chain ids pass', () => {
+    expect(() => new SwapperClient({ chainId: 8453 })).not.toThrow()
   })
 
   test('Other chain ids fail', () => {

--- a/packages/splits-sdk/src/client/templates.test.ts
+++ b/packages/splits-sdk/src/client/templates.test.ts
@@ -21,7 +21,7 @@ import {
   validateDistributorFeePercent,
   validateDiversifierRecipients,
   validateOracleParams,
-  validateRecipients,
+  validateSplitRecipients,
   validateRecoupNonWaterfallRecipient,
   validateRecoupTranches,
 } from '../utils/validation'
@@ -179,7 +179,7 @@ describe('Template writes', () => {
   )
 
   beforeEach(() => {
-    ;(validateRecipients as jest.Mock).mockClear()
+    ;(validateSplitRecipients as jest.Mock).mockClear()
     ;(validateDistributorFeePercent as jest.Mock).mockClear()
     ;(validateAddress as jest.Mock).mockClear()
     getRecoupTranchesAndSizesMock.mockClear()

--- a/packages/splits-sdk/src/client/waterfall.test.ts
+++ b/packages/splits-sdk/src/client/waterfall.test.ts
@@ -19,7 +19,7 @@ import {
 } from '../errors'
 import * as subgraph from '../subgraph'
 import * as utils from '../utils'
-import { validateAddress, validateTranches } from '../utils/validation'
+import { validateAddress, validateWaterfallTranches } from '../utils/validation'
 import {
   TRANCHE_RECIPIENTS,
   TRANCHE_SIZES,
@@ -176,7 +176,7 @@ describe('Waterfall writes', () => {
     })
 
   beforeEach(() => {
-    ;(validateTranches as jest.Mock).mockClear()
+    ;(validateWaterfallTranches as jest.Mock).mockClear()
     ;(validateAddress as jest.Mock).mockClear()
     getTransactionEventsSpy.mockClear()
     getTrancheRecipientsAndSizesMock.mockClear()
@@ -244,7 +244,7 @@ describe('Waterfall writes', () => {
       expect(event.blockNumber).toEqual(12345)
       expect(waterfallModuleAddress).toEqual('0xwaterfall')
       expect(validateAddress).toBeCalledWith(token)
-      expect(validateTranches).toBeCalledWith(tranches)
+      expect(validateWaterfallTranches).toBeCalledWith(tranches)
       expect(getTrancheRecipientsAndSizesMock).toBeCalledWith(
         1,
         token,
@@ -274,7 +274,7 @@ describe('Waterfall writes', () => {
       expect(event.blockNumber).toEqual(12345)
       expect(waterfallModuleAddress).toEqual('0xwaterfall')
       expect(validateAddress).toBeCalledWith(token)
-      expect(validateTranches).toBeCalledWith(tranches)
+      expect(validateWaterfallTranches).toBeCalledWith(tranches)
       expect(getTrancheRecipientsAndSizesMock).toBeCalledWith(
         1,
         token,

--- a/packages/splits-sdk/src/client/waterfall.ts
+++ b/packages/splits-sdk/src/client/waterfall.ts
@@ -54,7 +54,7 @@ import {
   getTokenData,
   addEnsNames,
 } from '../utils'
-import { validateAddress, validateTranches } from '../utils/validation'
+import { validateAddress, validateWaterfallTranches } from '../utils/validation'
 
 type WaterfallAbi = typeof waterfallAbi
 
@@ -85,7 +85,7 @@ class WaterfallTransactions extends BaseTransactions {
   }: CreateWaterfallConfig): Promise<TransactionFormat> {
     validateAddress(token)
     validateAddress(nonWaterfallRecipient)
-    validateTranches(tranches)
+    validateWaterfallTranches(tranches)
     this._requirePublicClient()
     if (!this._publicClient) throw new Error('Public client required')
     if (this._shouldRequreWalletClient) this._requireWalletClient()

--- a/packages/splits-sdk/src/index.ts
+++ b/packages/splits-sdk/src/index.ts
@@ -92,3 +92,5 @@ export type {
   PassThroughWalletPauseConfig,
   PassThroughWalletExecCallsConfig,
 } from './types'
+
+export { roundToDecimals } from './utils'

--- a/packages/splits-sdk/src/utils/index.ts
+++ b/packages/splits-sdk/src/utils/index.ts
@@ -37,6 +37,15 @@ import {
 import { erc20Abi } from '../constants/abi/erc20'
 import { reverseRecordsAbi } from '../constants/abi/reverseRecords'
 
+export const roundToDecimals: (arg0: number, arg1: number) => number = (
+  num,
+  decimals,
+) => {
+  const multiplier = Math.pow(10, decimals)
+  // Include Number.EPSILON to help with floating point precision (i.e. expected 1.325 but got 1.324999999999)
+  return Math.round((num + Number.EPSILON) * multiplier) / multiplier
+}
+
 export const getRecipientSortedAddressesAndAllocations = (
   recipients: SplitRecipient[],
 ): [Address[], bigint[]] => {

--- a/packages/splits-sdk/src/utils/validation.test.ts
+++ b/packages/splits-sdk/src/utils/validation.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../errors'
 import { SplitRecipient, WaterfallTrancheInput } from '../types'
 import {
-  validateRecipients,
+  validateSplitRecipients,
   validateDistributorFeePercent,
   validateAddress,
   validateWaterfallTranches,
@@ -68,43 +68,46 @@ describe('Recipients validation', () => {
   test('Percent allocation doesnt sum to 100 fails', () => {
     recipients[0].percentAllocation = 51
     expect(() =>
-      validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
     ).toThrow(InvalidRecipientsError)
   })
   test('Percent allocationt too many decimals fails', () => {
     recipients[0].percentAllocation = 49.99999
     recipients[1].percentAllocation = 50.00001
     expect(() =>
-      validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
     ).toThrow(InvalidRecipientsError)
   })
   test('Percent allocation outside valid range fails', () => {
     recipients[0].percentAllocation = 0
     recipients[1].percentAllocation = 100
     expect(() =>
-      validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
     ).toThrow(InvalidRecipientsError)
   })
   test('Repeat address fails', () => {
     recipients[1].address = recipients[0].address
     expect(() =>
-      validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
     ).toThrow(InvalidRecipientsError)
   })
   test('Less than two recipients fails', () => {
     expect(() =>
-      validateRecipients(recipients.slice(0, 1), SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(
+        recipients.slice(0, 1),
+        SPLITS_MAX_PRECISION_DECIMALS,
+      ),
     ).toThrow(InvalidRecipientsError)
   })
   test('Invalid address fails', () => {
     recipients[0].address = '12345'
     expect(() =>
-      validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
     ).toThrow(InvalidRecipientsError)
   })
   test('Valid recipients pass', () => {
     expect(() =>
-      validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
+      validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS),
     ).not.toThrow()
   })
 })

--- a/packages/splits-sdk/src/utils/validation.test.ts
+++ b/packages/splits-sdk/src/utils/validation.test.ts
@@ -9,7 +9,7 @@ import {
   validateRecipients,
   validateDistributorFeePercent,
   validateAddress,
-  validateTranches,
+  validateWaterfallTranches,
   validateVestingPeriod,
   validateRecoupNonWaterfallRecipient,
   validateDiversifierRecipients,
@@ -129,21 +129,27 @@ describe('Tranches validation', () => {
 
   test('Bad address fails', () => {
     tranches[0].recipient = '0xbadAddress'
-    expect(() => validateTranches(tranches)).toThrow(InvalidArgumentError)
+    expect(() => validateWaterfallTranches(tranches)).toThrow(
+      InvalidArgumentError,
+    )
   })
 
   test('Extra size fails', () => {
     tranches[2].size = 1
-    expect(() => validateTranches(tranches)).toThrow(InvalidArgumentError)
+    expect(() => validateWaterfallTranches(tranches)).toThrow(
+      InvalidArgumentError,
+    )
   })
 
   test('Missing size fails', () => {
     tranches[1].size = undefined
-    expect(() => validateTranches(tranches)).toThrow(InvalidArgumentError)
+    expect(() => validateWaterfallTranches(tranches)).toThrow(
+      InvalidArgumentError,
+    )
   })
 
   test('Valid tranches pass', () => {
-    expect(() => validateTranches(tranches)).not.toThrow()
+    expect(() => validateWaterfallTranches(tranches)).not.toThrow()
   })
 })
 

--- a/packages/splits-sdk/src/utils/validation.ts
+++ b/packages/splits-sdk/src/utils/validation.ts
@@ -24,7 +24,7 @@ const getNumDigitsAfterDecimal = (value: number): number => {
   return decimalStr.length
 }
 
-export const validateRecipients = (
+export const validateSplitRecipients = (
   recipients: SplitRecipient[],
   maxPrecisionDecimals: number,
 ): void => {
@@ -165,7 +165,7 @@ export const validateSplitInputs = ({
   controller = ADDRESS_ZERO,
 }: CreateSplitConfig): void => {
   validateAddress(controller)
-  validateRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS)
+  validateSplitRecipients(recipients, SPLITS_MAX_PRECISION_DECIMALS)
   validateDistributorFeePercent(distributorFeePercent)
 }
 

--- a/packages/splits-sdk/src/utils/validation.ts
+++ b/packages/splits-sdk/src/utils/validation.ts
@@ -16,6 +16,7 @@ import type {
   UniV3FlashSwapConfig,
   WaterfallTrancheInput,
 } from '../types'
+import { roundToDecimals } from '.'
 
 const getNumDigitsAfterDecimal = (value: number): number => {
   if (Number.isInteger(value)) return 0
@@ -59,9 +60,10 @@ export const validateSplitRecipients = (
 
   // Cutoff any decimals beyond the max precision, they may get introduced due
   // to javascript floating point precision
-  const factorOfTen = Math.pow(10, maxPrecisionDecimals)
-  totalPercentAllocation =
-    Math.round(totalPercentAllocation * factorOfTen) / factorOfTen
+  totalPercentAllocation = roundToDecimals(
+    totalPercentAllocation,
+    maxPrecisionDecimals,
+  )
   if (totalPercentAllocation !== 100)
     throw new InvalidRecipientsError(
       `Percent allocation must add up to 100. Currently adds up to ${totalPercentAllocation}`,
@@ -239,9 +241,10 @@ export const validateDiversifierRecipients = (
 
   // Cutoff any decimals beyond the max precision, they may get introduced due
   // to javascript floating point precision
-  const factorOfTen = Math.pow(10, SPLITS_MAX_PRECISION_DECIMALS)
-  totalPercentAllocation =
-    Math.round(totalPercentAllocation * factorOfTen) / factorOfTen
+  totalPercentAllocation = roundToDecimals(
+    totalPercentAllocation,
+    SPLITS_MAX_PRECISION_DECIMALS,
+  )
   if (totalPercentAllocation !== 100)
     throw new InvalidArgumentError(
       `Percent allocation must add up to 100. Currently adds up to ${totalPercentAllocation}`,

--- a/packages/splits-sdk/src/utils/validation.ts
+++ b/packages/splits-sdk/src/utils/validation.ts
@@ -90,7 +90,9 @@ export const validateAddress = (address: string): void => {
     throw new InvalidArgumentError(`Invalid address: ${address}`)
 }
 
-export const validateTranches = (tranches: WaterfallTrancheInput[]): void => {
+export const validateWaterfallTranches = (
+  tranches: WaterfallTrancheInput[],
+): void => {
   validateNumTranches(tranches.length)
   tranches.forEach((tranche, index) => {
     if (!isAddress(tranche.recipient))


### PR DESCRIPTION
- Expose all validation functions
- Rename `validateRecipients` --> `validateSplitRecipients`
- Rename `validateTranches` --> `validateWaterfallTranches`
- Add `roundToDecimals` function and expose it