### PR TITLE
feat(sdk): add warehouse balances to earnings

### DIFF
--- a/packages/splits-sdk/src/client/data.ts
+++ b/packages/splits-sdk/src/client/data.ts
@@ -86,6 +86,8 @@ import {
   isLogsPublicClient,
   validateAddress,
 } from '../utils'
+import { mergeWith } from 'lodash'
+import { ZERO } from '../constants'
 
 export class DataClient {
   readonly _ensPublicClient: PublicClient<Transport, Chain> | undefined
@@ -344,12 +346,20 @@ export class DataClient {
     }
 
     const internalBalances = formatAccountBalances(response.balances)
+    const warehouseBalances = formatAccountBalances(response.warehouseBalances)
     if (response.type === 'user') {
       // Only including split main balance for users
       return {
         withdrawn,
         distributed,
-        activeBalances: internalBalances,
+        activeBalances: mergeWith(
+          {},
+          internalBalances,
+          warehouseBalances,
+          (a: bigint, b: bigint) => {
+            return (a || ZERO) + (b || ZERO)
+          },
+        ),
       }
     }
 


### PR DESCRIPTION
Adds warehouse balances to active balances so the weekly email task can pick up v1 and v2 earnings for users and splits