### PR TITLE
React fixes

### DIFF
--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.2",
+  "version": "0.4.3-beta.0",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -32,7 +32,7 @@
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
     "@0xsplits/splits-sdk": "^4.0.2",
-    "@0xsplits/splits-sdk-react": "^2.0.2",
+    "@0xsplits/splits-sdk-react": "^2.0.3-beta.0",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.0.2",
+  "version": "2.0.3-beta.0",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/splits-sdk-react/src/hooks/data.ts
+++ b/packages/splits-sdk-react/src/hooks/data.ts
@@ -71,7 +71,7 @@ export const useSplitMetadata = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, splitAddress])
+  }, [splitsClient, chainId, splitAddress])
 
   return {
     isLoading,
@@ -144,7 +144,13 @@ export const useSplitEarnings = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, splitAddress, includeActiveBalances, erc20TokenList])
+  }, [
+    splitsClient,
+    chainId,
+    splitAddress,
+    includeActiveBalances,
+    erc20TokenList,
+  ])
 
   return {
     isLoading,
@@ -217,7 +223,13 @@ export const useContractEarnings = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, contractAddress, includeActiveBalances, erc20TokenList])
+  }, [
+    splitsClient,
+    chainId,
+    contractAddress,
+    includeActiveBalances,
+    erc20TokenList,
+  ])
 
   return {
     isLoading,
@@ -286,7 +298,7 @@ export const useLiquidSplitMetadata = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, liquidSplitAddress])
+  }, [splitsClient, chainId, liquidSplitAddress])
 
   return {
     isLoading,
@@ -353,7 +365,7 @@ export const useSwapperMetadata = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, swapperAddress])
+  }, [splitsClient, chainId, swapperAddress])
 
   return {
     isLoading,
@@ -426,7 +438,7 @@ export const useUserEarnings = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, userAddress])
+  }, [splitsClient, chainId, userAddress])
 
   return {
     isLoading,
@@ -503,7 +515,7 @@ export const useUserEarningsByContract = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, userAddress, contractAddressesString])
+  }, [splitsClient, chainId, userAddress, contractAddressesString])
 
   return {
     isLoading,
@@ -572,7 +584,7 @@ export const useVestingMetadata = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, vestingModuleAddress])
+  }, [splitsClient, chainId, vestingModuleAddress])
 
   return {
     isLoading,
@@ -641,7 +653,7 @@ export const useWaterfallMetadata = (
     return () => {
       isActive = false
     }
-  }, [splitsClient, waterfallModuleAddress])
+  }, [splitsClient, chainId, waterfallModuleAddress])
 
   return {
     isLoading,

--- a/packages/splits-sdk-react/src/hooks/data.ts
+++ b/packages/splits-sdk-react/src/hooks/data.ts
@@ -104,6 +104,8 @@ export const useSplitEarnings = (
   )
   const [error, setError] = useState<RequestError>()
 
+  const stringErc20List =
+    erc20TokenList !== undefined ? JSON.stringify(erc20TokenList) : undefined
   useEffect(() => {
     let isActive = true
 
@@ -115,7 +117,10 @@ export const useSplitEarnings = (
           chainId,
           splitAddress,
           includeActiveBalances,
-          erc20TokenList,
+          erc20TokenList:
+            stringErc20List !== undefined
+              ? JSON.parse(stringErc20List)
+              : undefined,
         })
         if (!isActive) return
         setSplitEarnings(earnings)
@@ -149,7 +154,7 @@ export const useSplitEarnings = (
     chainId,
     splitAddress,
     includeActiveBalances,
-    erc20TokenList,
+    stringErc20List,
   ])
 
   return {
@@ -183,6 +188,8 @@ export const useContractEarnings = (
   )
   const [error, setError] = useState<RequestError>()
 
+  const stringErc20List =
+    erc20TokenList !== undefined ? JSON.stringify(erc20TokenList) : undefined
   useEffect(() => {
     let isActive = true
 
@@ -194,7 +201,10 @@ export const useContractEarnings = (
           chainId,
           contractAddress,
           includeActiveBalances,
-          erc20TokenList,
+          erc20TokenList:
+            stringErc20List !== undefined
+              ? JSON.parse(stringErc20List)
+              : undefined,
         })
         if (!isActive) return
         setContractEarnings(earnings)
@@ -228,7 +238,7 @@ export const useContractEarnings = (
     chainId,
     contractAddress,
     includeActiveBalances,
-    erc20TokenList,
+    stringErc20List,
   ])
 
   return {

--- a/packages/splits-sdk-react/src/hooks/splitV1.ts
+++ b/packages/splits-sdk-react/src/hooks/splitV1.ts
@@ -1,5 +1,5 @@
 import { Log } from 'viem'
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import {
   SplitsClient,
   SplitsClientConfig,
@@ -24,10 +24,24 @@ export const useSplitsClient = (config?: SplitsClientConfig): SplitsClient => {
     throw new Error('Make sure to include <SplitsProvider>')
   }
 
-  const apiConfig =
+  // Since apiConfig is an object, if it gets set directly it'll be considered "new" on each render
+  const apiKey =
     config && 'apiConfig' in config
-      ? config.apiConfig
-      : context.splitsClient._apiConfig
+      ? config.apiConfig!.apiKey
+      : context.splitsClient._apiConfig?.apiKey
+  const serverUrl =
+    config && 'apiConfig' in config
+      ? config.apiConfig!.serverURL
+      : context.splitsClient._apiConfig?.serverURL
+  const apiConfig = useMemo(() => {
+    if (!apiKey) return
+
+    return {
+      apiKey,
+      serverUrl,
+    }
+  }, [apiKey, serverUrl])
+
   const chainId =
     config && 'chainId' in config
       ? config.chainId

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         specifier: ^4.0.2
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.0.2
+        specifier: ^2.0.3-beta.0
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17


### PR DESCRIPTION
- handles apiConfig object set directly on `useSplitsClient` (the object will be considered "new" on each render so need to find a way to memoize, i'm just grabbing the values which are strings so they won't be considered changing).
- handles `erc20TokenList` array set directly on hooks (same issue as above, but stringifies the array)
- includes chainId in dependency arrays for hooks where it's used
- includes `splitAddress` as another returned field on the create split hooks. let me know what you think of this. would be nice to return it from the function call like we do for the core sdk. but technically that would be a breaking change at this point :(

still left to think on / to do:
- handling changing values in the config passed to `SplitsProvider`. Want to think on that a bit more. Worried there was a reason I didn't add it originally, a bit nervous to do so now. But could have just been an oversight 🤷 