### PR TITLE
Refactor chain id and public client

### DIFF
--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.16",
+  "version": "0.4.3-beta.17",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-beta.1",
-    "@0xsplits/splits-sdk-react": "^2.1.0-beta.1",
+    "@0xsplits/splits-sdk": "^4.1.0-beta.2",
+    "@0xsplits/splits-sdk-react": "^2.1.0-beta.2",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.8",
+  "version": "0.4.3-beta.9",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.0",
-    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.0",
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.1",
+    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.1",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.9",
+  "version": "0.4.3-beta.12",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.1",
-    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.1",
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.2",
+    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.2",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.14",
+  "version": "0.4.3-beta.15",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.4",
-    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.4",
+    "@0xsplits/splits-sdk": "^4.1.0-beta.0",
+    "@0xsplits/splits-sdk-react": "^2.1.0-beta.0",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.12",
+  "version": "0.4.3-beta.13",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.2",
-    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.2",
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.3",
+    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.3",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.7",
+  "version": "0.4.3-beta.8",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.0.4",
-    "@0xsplits/splits-sdk-react": "^2.0.5",
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.0",
+    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.0",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.15",
+  "version": "0.4.3-beta.16",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-beta.0",
-    "@0xsplits/splits-sdk-react": "^2.1.0-beta.0",
+    "@0xsplits/splits-sdk": "^4.1.0-beta.1",
+    "@0xsplits/splits-sdk-react": "^2.1.0-beta.1",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "0.4.3-beta.13",
+  "version": "0.4.3-beta.14",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -31,8 +31,8 @@
   },
   "homepage": "https://docs.splits.org/sdk-info/overview",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.3",
-    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.3",
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.4",
+    "@0xsplits/splits-sdk-react": "^2.1.0-alpha.4",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@hookform/error-message": "^2.0.1",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-alpha.2",
+  "version": "2.1.0-alpha.3",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.2"
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.3"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-beta.1"
+    "@0xsplits/splits-sdk": "^4.1.0-beta.2"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-alpha.3",
+  "version": "2.1.0-alpha.4",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.3"
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.4"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.1"
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.2"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.0"
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.1"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.0.5",
+  "version": "2.1.0-alpha.0",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.0.4"
+    "@0xsplits/splits-sdk": "^4.1.0-alpha.0"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-beta.1",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-beta.0"
+    "@0xsplits/splits-sdk": "^4.1.0-beta.1"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "2.1.0-alpha.4",
+  "version": "2.1.0-beta.0",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "homepage": "https://docs.splits.org/sdk",
   "dependencies": {
-    "@0xsplits/splits-sdk": "^4.1.0-alpha.4"
+    "@0xsplits/splits-sdk": "^4.1.0-beta.0"
   },
   "peerDependencies": {
     "react": "17.x.x || 18.x.x",

--- a/packages/splits-sdk-react/src/hooks/splitV1.ts
+++ b/packages/splits-sdk-react/src/hooks/splitV1.ts
@@ -113,6 +113,12 @@ export const useCreateSplit = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitCreateSplitTransaction(argsDict)
 
@@ -121,7 +127,7 @@ export const useCreateSplit = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.createSplit,
+          eventTopics: eventTopics.createSplit,
         })
 
         const splitMainAbi =
@@ -178,6 +184,12 @@ export const useUpdateSplit = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitUpdateSplitTransaction(argsDict)
 
@@ -186,7 +198,7 @@ export const useUpdateSplit = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.updateSplit,
+          eventTopics: eventTopics.updateSplit,
         })
 
         setStatus('complete')
@@ -225,6 +237,12 @@ export const useDistributeToken = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitDistributeTokenTransaction(argsDict)
 
@@ -233,7 +251,7 @@ export const useDistributeToken = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.distributeToken,
+          eventTopics: eventTopics.distributeToken,
         })
 
         setStatus('complete')
@@ -274,6 +292,12 @@ export const useUpdateSplitAndDistributeToken = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitUpdateSplitAndDistributeTokenTransaction(
             argsDict,
@@ -284,7 +308,7 @@ export const useUpdateSplitAndDistributeToken = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.updateSplitAndDistributeToken,
+          eventTopics: eventTopics.updateSplitAndDistributeToken,
         })
 
         setStatus('complete')
@@ -323,6 +347,12 @@ export const useWithdrawFunds = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitWithdrawFundsTransaction(argsDict)
 
@@ -331,7 +361,7 @@ export const useWithdrawFunds = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.withdrawFunds,
+          eventTopics: eventTopics.withdrawFunds,
         })
 
         setStatus('complete')
@@ -372,6 +402,12 @@ export const useInitiateControlTransfer = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitInitiateControlTransferTransaction(argsDict)
 
@@ -380,7 +416,7 @@ export const useInitiateControlTransfer = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.initiateControlTransfer,
+          eventTopics: eventTopics.initiateControlTransfer,
         })
 
         setStatus('complete')
@@ -421,6 +457,12 @@ export const useCancelControlTransfer = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitCancelControlTransferTransaction(argsDict)
 
@@ -429,7 +471,7 @@ export const useCancelControlTransfer = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.cancelControlTransfer,
+          eventTopics: eventTopics.cancelControlTransfer,
         })
 
         setStatus('complete')
@@ -470,6 +512,12 @@ export const useAcceptControlTransfer = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitAcceptControlTransferTransaction(argsDict)
 
@@ -478,7 +526,7 @@ export const useAcceptControlTransfer = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.acceptControlTransfer,
+          eventTopics: eventTopics.acceptControlTransfer,
         })
 
         setStatus('complete')
@@ -519,6 +567,12 @@ export const useMakeSplitImmutable = (): {
         setError(undefined)
         setTxHash(undefined)
 
+        const chainId = splitsClient._walletClient?.chain.id
+        if (!chainId) {
+          throw new Error('Wallet client required')
+        }
+        const eventTopics = splitsClient.getEventTopics(chainId)
+
         const { txHash: hash } =
           await splitsClient.submitMakeSplitImmutableTransaction(argsDict)
 
@@ -527,7 +581,7 @@ export const useMakeSplitImmutable = (): {
 
         const events = await splitsClient.getTransactionEvents({
           txHash: hash,
-          eventTopics: splitsClient.eventTopics.makeSplitImmutable,
+          eventTopics: eventTopics.makeSplitImmutable,
         })
 
         setStatus('complete')

--- a/packages/splits-sdk-react/src/hooks/splitV1.ts
+++ b/packages/splits-sdk-react/src/hooks/splitV1.ts
@@ -47,6 +47,16 @@ export const useSplitsClient = (config?: SplitsClientConfig): SplitsClient => {
     }
   }, [apiKey, serverURL])
 
+  // Since publicClients is an array, if it gets set directly it'll be considered "new" on each render
+  const stringPublicClients =
+    config && 'publicClients' in config
+      ? JSON.stringify(config.publicClients)
+      : undefined
+  const publicClients = useMemo(() => {
+    if (stringPublicClients) return config!.publicClients
+    return context.splitsClient._publicClients
+  }, [stringPublicClients])
+
   const chainId =
     config && 'chainId' in config
       ? config.chainId
@@ -69,8 +79,9 @@ export const useSplitsClient = (config?: SplitsClientConfig): SplitsClient => {
       : context.splitsClient._ensPublicClient
   useEffect(() => {
     context.initClient({
-      chainId: chainId!,
+      chainId,
       publicClient,
+      publicClients,
       walletClient,
       apiConfig,
       includeEnsNames,
@@ -79,6 +90,7 @@ export const useSplitsClient = (config?: SplitsClientConfig): SplitsClient => {
   }, [
     chainId,
     publicClient,
+    publicClients,
     walletClient,
     apiConfig,
     includeEnsNames,

--- a/packages/splits-sdk-react/src/hooks/splitV1.ts
+++ b/packages/splits-sdk-react/src/hooks/splitV1.ts
@@ -34,7 +34,7 @@ export const useSplitsClient = (config?: SplitsClientConfig): SplitsClient => {
     config && 'apiConfig' in config
       ? config.apiConfig!.apiKey
       : context.splitsClient._apiConfig?.apiKey
-  const serverUrl =
+  const serverURL =
     config && 'apiConfig' in config
       ? config.apiConfig!.serverURL
       : context.splitsClient._apiConfig?.serverURL
@@ -43,9 +43,9 @@ export const useSplitsClient = (config?: SplitsClientConfig): SplitsClient => {
 
     return {
       apiKey,
-      serverUrl,
+      serverURL,
     }
-  }, [apiKey, serverUrl])
+  }, [apiKey, serverURL])
 
   const chainId =
     config && 'chainId' in config

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-alpha.1",
+  "version": "4.1.0-alpha.2",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.0.4",
+  "version": "4.1.0-alpha.0",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-alpha.4",
+  "version": "4.1.0-beta.0",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-beta.0",
+  "version": "4.1.0-beta.1",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-beta.1",
+  "version": "4.1.0-beta.2",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-alpha.3",
+  "version": "4.1.0-alpha.4",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-alpha.2",
+  "version": "4.1.0-alpha.3",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "4.1.0-alpha.0",
+  "version": "4.1.0-alpha.1",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -238,6 +238,16 @@ export class BaseTransactions extends BaseClient {
 
   protected _getFunctionChainId(argumentChainId?: number) {
     if (this._shouldRequireWalletClient) {
+      if (
+        argumentChainId !== undefined &&
+        this._walletClient!.chain.id !== argumentChainId
+      ) {
+        throw new InvalidArgumentError(
+          `Passed in chain id ${argumentChainId} does not match walletClient chain id: ${
+            this._walletClient!.chain.id
+          }.`,
+        )
+      }
       return this._walletClient!.chain.id
     }
 

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -130,13 +130,16 @@ class BaseClient {
   }
 
   protected _getPublicClient(chainId: number): PublicClient<Transport, Chain> {
+    if (!this._supportedChainIds.includes(chainId))
+      throw new UnsupportedChainIdError(chainId, this._supportedChainIds)
+
     if (this._publicClients && this._publicClients[chainId]) {
       return this._publicClients[chainId]
     }
 
     if (!this._publicClient)
       throw new MissingPublicClientError(
-        'Public client required to perform this action, please update your call to the constructor',
+        `Public client required on chain ${chainId} to perform this action, please update your call to the constructor`,
       )
 
     return this._publicClient

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -36,7 +36,7 @@ import { DataClient } from './data'
 
 class BaseClient {
   readonly _chainId: number | undefined // DEPRECATED
-  readonly _ensPublicClient: PublicClient<Transport, Chain> | undefined
+  readonly _ensPublicClient: PublicClient<Transport, Chain> | undefined // DEPRECATED
   readonly _walletClient: WalletClient<Transport, Chain, Account> | undefined
   readonly _publicClient: PublicClient<Transport, Chain> | undefined // DEPRECATED
   readonly _publicClients:
@@ -65,7 +65,7 @@ class BaseClient {
       )
 
     this._ensPublicClient =
-      ensPublicClient ?? publicClients?.[1] ?? publicClient
+      publicClients?.[1] ?? ensPublicClient ?? publicClient
     this._publicClient = publicClient
     this._publicClients = publicClients
     this._chainId = chainId

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -15,6 +15,7 @@ import {
 import { MULTICALL_3_ADDRESS, TransactionType } from '../constants'
 import { multicallAbi } from '../constants/abi/multicall'
 import {
+  InvalidArgumentError,
   InvalidConfigError,
   MissingDataClientError,
   MissingPublicClientError,
@@ -103,6 +104,15 @@ class BaseClient {
     const chainId = this._walletClient.chain.id
     if (!this._supportedChainIds.includes(chainId))
       throw new UnsupportedChainIdError(chainId, this._supportedChainIds)
+  }
+
+  protected _getFunctionChainId(argumentChainId?: number) {
+    const functionChainId =
+      this._walletClient?.chain.id ?? argumentChainId ?? this._chainId
+    if (!functionChainId)
+      throw new InvalidArgumentError('Please pass in the chainId you are using')
+
+    return functionChainId
   }
 }
 

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -64,7 +64,8 @@ class BaseClient {
         'Must include a mainnet public client if includeEnsNames is set to true',
       )
 
-    this._ensPublicClient = ensPublicClient ?? publicClient
+    this._ensPublicClient =
+      ensPublicClient ?? publicClients?.[1] ?? publicClient
     this._publicClient = publicClient
     this._publicClients = publicClients
     this._chainId = chainId

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -136,23 +136,9 @@ export class BaseTransactions extends BaseClient {
 
   constructor({
     transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    supportedChainIds,
-    includeEnsNames = false,
+    ...baseClientArgs
   }: BaseClientConfig & TransactionConfig) {
-    super({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      supportedChainIds,
-      includeEnsNames,
-    })
+    super(baseClientArgs)
 
     this._transactionType = transactionType
     this._shouldRequireWalletClient = [

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -111,24 +111,6 @@ class BaseClient {
     this._requirePublicClient(chainId)
   }
 
-  protected _getFunctionChainId(argumentChainId?: number) {
-    const functionChainId =
-      this._walletClient?.chain.id ?? argumentChainId ?? this._chainId
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
-    return functionChainId
-  }
-
-  // Ignore wallet client here
-  protected _getReadOnlyFunctionChainId(argumentChainId?: number) {
-    const functionChainId = argumentChainId ?? this._chainId
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
-    return functionChainId
-  }
-
   protected _getPublicClient(chainId: number): PublicClient<Transport, Chain> {
     if (!this._supportedChainIds.includes(chainId))
       throw new UnsupportedChainIdError(chainId, this._supportedChainIds)
@@ -252,6 +234,23 @@ export class BaseTransactions extends BaseClient {
     if (typeof callData === 'string') return false
 
     return true
+  }
+
+  protected _getFunctionChainId(argumentChainId?: number) {
+    if (this._shouldRequireWalletClient) {
+      return this._walletClient!.chain.id
+    }
+
+    return this._getReadOnlyFunctionChainId(argumentChainId)
+  }
+
+  // Ignore wallet client here
+  protected _getReadOnlyFunctionChainId(argumentChainId?: number) {
+    const functionChainId = argumentChainId ?? this._chainId
+    if (!functionChainId)
+      throw new InvalidArgumentError('Please pass in the chainId you are using')
+
+    return functionChainId
   }
 
   async _multicallTransaction({

--- a/packages/splits-sdk/src/client/base.ts
+++ b/packages/splits-sdk/src/client/base.ts
@@ -77,6 +77,7 @@ class BaseClient {
     if (apiConfig) {
       this._dataClient = new DataClient({
         publicClient,
+        publicClients,
         ensPublicClient,
         apiConfig,
         includeEnsNames,

--- a/packages/splits-sdk/src/client/client.test.ts
+++ b/packages/splits-sdk/src/client/client.test.ts
@@ -13,7 +13,6 @@ import {
   InvalidConfigError,
   MissingPublicClientError,
   MissingWalletClientError,
-  UnsupportedChainIdError,
 } from '../errors'
 import * as utils from '../utils'
 import * as numberUtils from '../utils/numbers'
@@ -25,7 +24,6 @@ import {
   CONTROLLER_ADDRESS,
   NEW_CONTROLLER_ADDRESS,
 } from '../testing/constants'
-import { MockGraphqlClient } from '../testing/mocks/graphql'
 import { readActions, writeActions } from '../testing/mocks/splitMain'
 import type { Split } from '../types'
 import { MockViemContract } from '../testing/mocks/viemContract'
@@ -89,6 +87,9 @@ const mockWalletClient = jest.fn(() => {
     account: {
       address: CONTROLLER_ADDRESS,
     },
+    chain: {
+      id: 1,
+    },
     writeContract: jest.fn(() => {
       return '0xhash'
     }),
@@ -99,6 +100,9 @@ const mockWalletClientNonController = jest.fn(() => {
     account: {
       address: '0xnotController',
     },
+    chain: {
+      id: 1,
+    },
     writeContract: jest.fn(() => {
       return '0xhash'
     }),
@@ -108,6 +112,9 @@ const mockWalletClientNewController = jest.fn(() => {
   return {
     account: {
       address: NEW_CONTROLLER_ADDRESS,
+    },
+    chain: {
+      id: 1,
     },
     writeContract: jest.fn(() => {
       return '0xhash'
@@ -144,41 +151,6 @@ describe('Client config validation', () => {
           publicClient,
         }),
     ).not.toThrow()
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new SplitsClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 1 })).not.toThrow()
-  })
-
-  test('Polygon chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 137 })).not.toThrow()
-  })
-
-  test('Optimism chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 10 })).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 42161 })).not.toThrow()
-  })
-
-  test('Zora chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 7777777 })).not.toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 8453 })).not.toThrow()
-  })
-
-  test('Other chain ids pass', () => {
-    expect(() => new SplitsClient({ chainId: 100 })).not.toThrow()
-    expect(() => new SplitsClient({ chainId: 56 })).not.toThrow()
   })
 })
 
@@ -229,6 +201,7 @@ describe('SplitMain writes', () => {
     test('Create split fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -332,6 +305,7 @@ describe('SplitMain writes', () => {
     test('Update split fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -448,6 +422,7 @@ describe('SplitMain writes', () => {
     test('Distribute token fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -610,6 +585,7 @@ describe('SplitMain writes', () => {
     test('Update and distribute fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -817,6 +793,7 @@ describe('SplitMain writes', () => {
     test('Withdraw fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -897,6 +874,7 @@ describe('SplitMain writes', () => {
     test('Initiate transfer fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -978,6 +956,7 @@ describe('SplitMain writes', () => {
     test('Cancel transfer fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -1048,6 +1027,7 @@ describe('SplitMain writes', () => {
     test('Accept transfer fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -1131,6 +1111,7 @@ describe('SplitMain writes', () => {
     test('Make immutable fails with no provider', async () => {
       const badSplitsClient = new SplitsClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -1378,14 +1359,4 @@ describe('SplitMain reads', () => {
       expect(readActions.getHash).toBeCalledWith([splitAddress])
     })
   })
-})
-
-const mockGqlClient = new MockGraphqlClient()
-jest.mock('graphql-request', () => {
-  return {
-    GraphQLClient: jest.fn().mockImplementation(() => {
-      return mockGqlClient
-    }),
-    gql: jest.fn(),
-  }
 })

--- a/packages/splits-sdk/src/client/client.test.ts
+++ b/packages/splits-sdk/src/client/client.test.ts
@@ -279,7 +279,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.createSplit[0]],
+        eventTopics: [splitsClient.getEventTopics(1).createSplit[0]],
       })
     })
 
@@ -310,7 +310,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.createSplit[0]],
+        eventTopics: [splitsClient.getEventTopics(1).createSplit[0]],
       })
     })
   })
@@ -403,7 +403,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.updateSplit[0]],
+        eventTopics: [splitsClient.getEventTopics(1).updateSplit[0]],
       })
     })
   })
@@ -495,7 +495,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.distributeToken[0]],
+        eventTopics: [splitsClient.getEventTopics(1).distributeToken[0]],
       })
     })
 
@@ -522,7 +522,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.distributeToken[1]],
+        eventTopics: [splitsClient.getEventTopics(1).distributeToken[1]],
       })
     })
 
@@ -549,7 +549,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.distributeToken[0]],
+        eventTopics: [splitsClient.getEventTopics(1).distributeToken[0]],
       })
     })
 
@@ -578,7 +578,7 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.distributeToken[1]],
+        eventTopics: [splitsClient.getEventTopics(1).distributeToken[1]],
       })
     })
   })
@@ -689,7 +689,7 @@ describe('SplitMain writes', () => {
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
         eventTopics: [
-          splitsClient.eventTopics.updateSplitAndDistributeToken[1],
+          splitsClient.getEventTopics(1).updateSplitAndDistributeToken[1],
         ],
       })
     })
@@ -724,7 +724,7 @@ describe('SplitMain writes', () => {
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
         eventTopics: [
-          splitsClient.eventTopics.updateSplitAndDistributeToken[2],
+          splitsClient.getEventTopics(1).updateSplitAndDistributeToken[2],
         ],
       })
     })
@@ -759,7 +759,7 @@ describe('SplitMain writes', () => {
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
         eventTopics: [
-          splitsClient.eventTopics.updateSplitAndDistributeToken[1],
+          splitsClient.getEventTopics(1).updateSplitAndDistributeToken[1],
         ],
       })
     })
@@ -796,7 +796,7 @@ describe('SplitMain writes', () => {
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
         eventTopics: [
-          splitsClient.eventTopics.updateSplitAndDistributeToken[2],
+          splitsClient.getEventTopics(1).updateSplitAndDistributeToken[2],
         ],
       })
     })
@@ -856,7 +856,7 @@ describe('SplitMain writes', () => {
       expect(writeActions.withdraw).toBeCalledWith(address, 1, ['0xerc20'])
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.withdrawFunds[0]],
+        eventTopics: [splitsClient.getEventTopics(1).withdrawFunds[0]],
       })
     })
 
@@ -876,7 +876,7 @@ describe('SplitMain writes', () => {
       ])
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.withdrawFunds[0]],
+        eventTopics: [splitsClient.getEventTopics(1).withdrawFunds[0]],
       })
     })
   })
@@ -954,7 +954,9 @@ describe('SplitMain writes', () => {
       )
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.initiateControlTransfer[0]],
+        eventTopics: [
+          splitsClient.getEventTopics(1).initiateControlTransfer[0],
+        ],
       })
     })
   })
@@ -1026,7 +1028,7 @@ describe('SplitMain writes', () => {
       expect(writeActions.cancelControlTransfer).toBeCalledWith(splitAddress)
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.cancelControlTransfer[0]],
+        eventTopics: [splitsClient.getEventTopics(1).cancelControlTransfer[0]],
       })
     })
   })
@@ -1107,7 +1109,7 @@ describe('SplitMain writes', () => {
       expect(writeActions.acceptControl).toBeCalledWith(splitAddress)
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.acceptControlTransfer[0]],
+        eventTopics: [splitsClient.getEventTopics(1).acceptControlTransfer[0]],
       })
     })
   })
@@ -1179,7 +1181,7 @@ describe('SplitMain writes', () => {
       expect(writeActions.makeSplitImmutable).toBeCalledWith(splitAddress)
       expect(getTransactionEventsSpy).toBeCalledWith({
         txHash: '0xhash',
-        eventTopics: [splitsClient.eventTopics.makeSplitImmutable[0]],
+        eventTopics: [splitsClient.getEventTopics(1).makeSplitImmutable[0]],
       })
     })
   })

--- a/packages/splits-sdk/src/client/data.ts
+++ b/packages/splits-sdk/src/client/data.ts
@@ -106,7 +106,8 @@ export class DataClient {
         'Must include a mainnet public client if includeEnsNames is set to true',
       )
 
-    this._ensPublicClient = ensPublicClient ?? publicClient
+    this._ensPublicClient =
+      ensPublicClient ?? publicClients?.[1] ?? publicClient
     this._publicClient = publicClient
     this._publicClients = publicClients
     this._includeEnsNames = includeEnsNames

--- a/packages/splits-sdk/src/client/data.ts
+++ b/packages/splits-sdk/src/client/data.ts
@@ -84,7 +84,7 @@ import {
 } from '../utils'
 
 export class DataClient {
-  readonly _ensPublicClient: PublicClient<Transport, Chain> | undefined
+  readonly _ensPublicClient: PublicClient<Transport, Chain> | undefined // DEPRECATED
   readonly _publicClient: PublicClient<Transport, Chain> | undefined // DEPRECATED
   readonly _publicClients:
     | {
@@ -101,13 +101,18 @@ export class DataClient {
     apiConfig,
     includeEnsNames = false,
   }: DataClientConfig) {
-    if (includeEnsNames && !publicClient && !ensPublicClient)
+    if (
+      includeEnsNames &&
+      !publicClient &&
+      !publicClients?.[1] &&
+      !ensPublicClient
+    )
       throw new InvalidConfigError(
         'Must include a mainnet public client if includeEnsNames is set to true',
       )
 
     this._ensPublicClient =
-      ensPublicClient ?? publicClients?.[1] ?? publicClient
+      publicClients?.[1] ?? ensPublicClient ?? publicClient
     this._publicClient = publicClient
     this._publicClients = publicClients
     this._includeEnsNames = includeEnsNames

--- a/packages/splits-sdk/src/client/data.ts
+++ b/packages/splits-sdk/src/client/data.ts
@@ -85,12 +85,18 @@ import {
 
 export class DataClient {
   readonly _ensPublicClient: PublicClient<Transport, Chain> | undefined
-  readonly _publicClient: PublicClient<Transport, Chain> | undefined
+  readonly _publicClient: PublicClient<Transport, Chain> | undefined // DEPRECATED
+  readonly _publicClients:
+    | {
+        [chainId: number]: PublicClient<Transport, Chain>
+      }
+    | undefined
   private readonly _graphqlClient: Client | undefined
   readonly _includeEnsNames: boolean
 
   constructor({
     publicClient,
+    publicClients,
     ensPublicClient,
     apiConfig,
     includeEnsNames = false,
@@ -102,16 +108,27 @@ export class DataClient {
 
     this._ensPublicClient = ensPublicClient ?? publicClient
     this._publicClient = publicClient
+    this._publicClients = publicClients
     this._includeEnsNames = includeEnsNames
 
     this._graphqlClient = getGraphqlClient(apiConfig)
   }
 
-  protected _requirePublicClient() {
+  protected _requirePublicClient(chainId: number) {
+    this._getPublicClient(chainId)
+  }
+
+  protected _getPublicClient(chainId: number): PublicClient<Transport, Chain> {
+    if (this._publicClients && this._publicClients[chainId]) {
+      return this._publicClients[chainId]
+    }
+
     if (!this._publicClient)
       throw new MissingPublicClientError(
-        'Public client required to perform this action, please update your call to the constructor',
+        `Public client required on chain ${chainId} to perform this action, please update your call to the constructor`,
       )
+
+    return this._publicClient
   }
 
   protected async _makeGqlRequest<ResponseType>(
@@ -322,7 +339,7 @@ export class DataClient {
     distributed: FormattedTokenBalances
     activeBalances?: FormattedTokenBalances
   }> {
-    const functionPublicClient = this._publicClient
+    const functionPublicClient = this._getPublicClient(chainId)
 
     const response = await this._loadAccount(accountAddress, chainId)
 
@@ -474,10 +491,7 @@ export class DataClient {
     erc20TokenList?: string[]
   }): Promise<FormattedContractEarnings> {
     validateAddress(contractAddress)
-    if (includeActiveBalances && !this._publicClient)
-      throw new MissingPublicClientError(
-        'Public client required to get contract active balances. Please update your call to the SplitsClient constructor with a valid public client, or set includeActiveBalances to false',
-      )
+    if (includeActiveBalances) this._requirePublicClient(chainId)
 
     const { distributed, activeBalances } = await this._getAccountBalances({
       chainId,
@@ -515,7 +529,7 @@ export class DataClient {
     accountAddress: string
   }): Promise<SplitsContract | undefined> {
     validateAddress(accountAddress)
-    this._requirePublicClient()
+    this._requirePublicClient(chainId)
 
     const response = await this._loadAccount(accountAddress, chainId)
 
@@ -584,8 +598,7 @@ export class DataClient {
     erc20TokenList?: string[]
   }): Promise<FormattedSplitEarnings> {
     validateAddress(splitAddress)
-    if (includeActiveBalances && !this._publicClient)
-      this._requirePublicClient()
+    if (includeActiveBalances) this._requirePublicClient(chainId)
 
     const { distributed, activeBalances } = await this._getAccountBalances({
       chainId,
@@ -717,7 +730,7 @@ export class DataClient {
         chainId,
       )
 
-    return await this.formatLiquidSplit(response)
+    return await this.formatLiquidSplit(chainId, response)
   }
 
   async getSwapperMetadata({
@@ -790,7 +803,7 @@ export class DataClient {
     else if (gqlAccount.type === 'waterfall')
       return await this.formatWaterfallModule(chainId, gqlAccount)
     else if (gqlAccount.type === 'liquidSplit')
-      return await this.formatLiquidSplit(gqlAccount)
+      return await this.formatLiquidSplit(chainId, gqlAccount)
     else if (gqlAccount.type === 'swapper')
       return await this.formatSwapper(gqlAccount)
   }
@@ -799,13 +812,13 @@ export class DataClient {
     chainId: number,
     gqlWaterfallModule: IWaterfallModule,
   ): Promise<WaterfallModule> {
-    this._requirePublicClient()
-    if (!this._publicClient) throw new Error()
+    this._requirePublicClient(chainId)
+    const publicClient = this._getPublicClient(chainId)
 
     const tokenData = await getTokenData(
       chainId,
       getAddress(gqlWaterfallModule.token),
-      this._publicClient,
+      publicClient,
     )
 
     const waterfallModule = protectedFormatWaterfallModule(
@@ -823,10 +836,7 @@ export class DataClient {
             ? [waterfallModule.nonWaterfallRecipient]
             : [],
         )
-      await addEnsNames(
-        this._ensPublicClient ?? this._publicClient,
-        ensRecipients,
-      )
+      await addEnsNames(this._ensPublicClient ?? publicClient, ensRecipients)
     }
 
     return waterfallModule
@@ -836,9 +846,8 @@ export class DataClient {
     chainId: number,
     gqlVestingModule: IVestingModule,
   ): Promise<VestingModule> {
-    this._requirePublicClient()
-    const publicClient = this._publicClient
-    if (!publicClient) throw new Error()
+    this._requirePublicClient(chainId)
+    const publicClient = this._getPublicClient(chainId)
 
     const tokenIds = Array.from(
       new Set(gqlVestingModule.streams?.map((stream) => stream.token) ?? []),
@@ -886,9 +895,10 @@ export class DataClient {
   }
 
   private async formatLiquidSplit(
+    chainId: number,
     gqlLiquidSplit: ILiquidSplit,
   ): Promise<LiquidSplit> {
-    this._requirePublicClient()
+    this._requirePublicClient(chainId)
 
     const liquidSplit = protectedFormatLiquidSplit(gqlLiquidSplit)
     if (this._includeEnsNames) {

--- a/packages/splits-sdk/src/client/index.ts
+++ b/packages/splits-sdk/src/client/index.ts
@@ -1,15 +1,4 @@
-import {
-  LIQUID_SPLIT_CHAIN_IDS,
-  ORACLE_CHAIN_IDS,
-  PASS_THROUGH_WALLET_CHAIN_IDS,
-  SPLITS_SUPPORTED_CHAIN_IDS,
-  SPLITS_V2_SUPPORTED_CHAIN_IDS,
-  SWAPPER_CHAIN_IDS,
-  TEMPLATES_CHAIN_IDS,
-  TransactionType,
-  VESTING_CHAIN_IDS,
-  WATERFALL_CHAIN_IDS,
-} from '../constants'
+import { TransactionType } from '../constants'
 import { SplitsClientConfig } from '../types'
 import {
   BaseClientMixin,
@@ -31,16 +20,16 @@ import { WaterfallClient } from './waterfall'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SplitsClient extends BaseTransactions {
-  readonly waterfall: WaterfallClient | undefined
-  readonly liquidSplits: LiquidSplitClient | undefined
-  readonly passThroughWallet: PassThroughWalletClient | undefined
-  readonly vesting: VestingClient | undefined
-  readonly oracle: OracleClient | undefined
-  readonly swapper: SwapperClient | undefined
-  readonly templates: TemplatesClient | undefined
-  readonly splitV1: SplitV1Client | undefined
-  readonly splitV2: SplitV2Client | undefined
-  readonly warehouse: WarehouseClient | undefined
+  readonly waterfall: WaterfallClient
+  readonly liquidSplits: LiquidSplitClient
+  readonly passThroughWallet: PassThroughWalletClient
+  readonly vesting: VestingClient
+  readonly oracle: OracleClient
+  readonly swapper: SwapperClient
+  readonly templates: TemplatesClient
+  readonly splitV1: SplitV1Client
+  readonly splitV2: SplitV2Client
+  readonly warehouse: WarehouseClient
   readonly dataClient: DataClient | undefined
   readonly estimateGas: SplitsClientGasEstimates
 
@@ -60,105 +49,88 @@ export class SplitsClient extends BaseTransactions {
       apiConfig,
       includeEnsNames,
       ensPublicClient,
+      supportedChainIds: [],
     })
-    if (WATERFALL_CHAIN_IDS.includes(chainId)) {
-      this.waterfall = new WaterfallClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (LIQUID_SPLIT_CHAIN_IDS.includes(chainId)) {
-      this.liquidSplits = new LiquidSplitClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (VESTING_CHAIN_IDS.includes(chainId)) {
-      this.vesting = new VestingClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (TEMPLATES_CHAIN_IDS.includes(chainId)) {
-      this.templates = new TemplatesClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (ORACLE_CHAIN_IDS.includes(chainId)) {
-      this.oracle = new OracleClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (SWAPPER_CHAIN_IDS.includes(chainId)) {
-      this.swapper = new SwapperClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (PASS_THROUGH_WALLET_CHAIN_IDS.includes(chainId)) {
-      this.passThroughWallet = new PassThroughWalletClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (SPLITS_SUPPORTED_CHAIN_IDS.includes(chainId)) {
-      this.splitV1 = new SplitV1Client({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
-    if (SPLITS_V2_SUPPORTED_CHAIN_IDS.includes(chainId)) {
-      this.splitV2 = new SplitV2Client({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-      this.warehouse = new WarehouseClient({
-        chainId,
-        publicClient,
-        ensPublicClient,
-        walletClient,
-        apiConfig,
-        includeEnsNames,
-      })
-    }
+    this.waterfall = new WaterfallClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.liquidSplits = new LiquidSplitClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.vesting = new VestingClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.templates = new TemplatesClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.oracle = new OracleClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.swapper = new SwapperClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.passThroughWallet = new PassThroughWalletClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.splitV1 = new SplitV1Client({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.splitV2 = new SplitV2Client({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
+    this.warehouse = new WarehouseClient({
+      chainId,
+      publicClient,
+      ensPublicClient,
+      walletClient,
+      apiConfig,
+      includeEnsNames,
+    })
 
     if (apiConfig) {
       this.dataClient = new DataClient({
@@ -202,6 +174,7 @@ class SplitsClientGasEstimates extends BaseTransactions {
       apiConfig,
       includeEnsNames,
       ensPublicClient,
+      supportedChainIds: [],
     })
   }
 }

--- a/packages/splits-sdk/src/client/index.ts
+++ b/packages/splits-sdk/src/client/index.ts
@@ -36,6 +36,7 @@ export class SplitsClient extends BaseTransactions {
   constructor({
     chainId,
     publicClient,
+    publicClients,
     walletClient,
     apiConfig,
     includeEnsNames = false,
@@ -45,6 +46,7 @@ export class SplitsClient extends BaseTransactions {
       transactionType: TransactionType.Transaction,
       chainId,
       publicClient,
+      publicClients,
       walletClient,
       apiConfig,
       includeEnsNames,
@@ -54,6 +56,7 @@ export class SplitsClient extends BaseTransactions {
     this.waterfall = new WaterfallClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -62,6 +65,7 @@ export class SplitsClient extends BaseTransactions {
     this.liquidSplits = new LiquidSplitClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -70,6 +74,7 @@ export class SplitsClient extends BaseTransactions {
     this.vesting = new VestingClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -78,6 +83,7 @@ export class SplitsClient extends BaseTransactions {
     this.templates = new TemplatesClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -86,6 +92,7 @@ export class SplitsClient extends BaseTransactions {
     this.oracle = new OracleClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -94,6 +101,7 @@ export class SplitsClient extends BaseTransactions {
     this.swapper = new SwapperClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -102,6 +110,7 @@ export class SplitsClient extends BaseTransactions {
     this.passThroughWallet = new PassThroughWalletClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -110,6 +119,7 @@ export class SplitsClient extends BaseTransactions {
     this.splitV1 = new SplitV1Client({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -118,6 +128,7 @@ export class SplitsClient extends BaseTransactions {
     this.splitV2 = new SplitV2Client({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -126,6 +137,7 @@ export class SplitsClient extends BaseTransactions {
     this.warehouse = new WarehouseClient({
       chainId,
       publicClient,
+      publicClients,
       ensPublicClient,
       walletClient,
       apiConfig,
@@ -135,6 +147,7 @@ export class SplitsClient extends BaseTransactions {
     if (apiConfig) {
       this.dataClient = new DataClient({
         publicClient,
+        publicClients,
         ensPublicClient,
         includeEnsNames,
         apiConfig,
@@ -144,6 +157,7 @@ export class SplitsClient extends BaseTransactions {
     this.estimateGas = new SplitsClientGasEstimates({
       chainId,
       publicClient,
+      publicClients,
       walletClient,
       ensPublicClient,
       apiConfig,

--- a/packages/splits-sdk/src/client/index.ts
+++ b/packages/splits-sdk/src/client/index.ts
@@ -1,4 +1,4 @@
-import { TransactionType } from '../constants'
+import { ALL_CHAIN_IDS, TransactionType } from '../constants'
 import { SplitsClientConfig } from '../types'
 import {
   BaseClientMixin,
@@ -36,7 +36,7 @@ export class SplitsClient extends BaseTransactions {
   constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      supportedChainIds: [],
+      supportedChainIds: ALL_CHAIN_IDS,
       ...clientArgs,
     })
     this.waterfall = new WaterfallClient(clientArgs)
@@ -73,7 +73,7 @@ class SplitsClientGasEstimates extends BaseTransactions {
   constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      supportedChainIds: [],
+      supportedChainIds: ALL_CHAIN_IDS,
       ...clientArgs,
     })
   }

--- a/packages/splits-sdk/src/client/index.ts
+++ b/packages/splits-sdk/src/client/index.ts
@@ -33,136 +33,34 @@ export class SplitsClient extends BaseTransactions {
   readonly dataClient: DataClient | undefined
   readonly estimateGas: SplitsClientGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    publicClients,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-    ensPublicClient,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      publicClients,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
       supportedChainIds: [],
+      ...clientArgs,
     })
-    this.waterfall = new WaterfallClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.liquidSplits = new LiquidSplitClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.vesting = new VestingClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.templates = new TemplatesClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.oracle = new OracleClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.swapper = new SwapperClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.passThroughWallet = new PassThroughWalletClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.splitV1 = new SplitV1Client({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.splitV2 = new SplitV2Client({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.warehouse = new WarehouseClient({
-      chainId,
-      publicClient,
-      publicClients,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.waterfall = new WaterfallClient(clientArgs)
+    this.liquidSplits = new LiquidSplitClient(clientArgs)
+    this.vesting = new VestingClient(clientArgs)
+    this.templates = new TemplatesClient(clientArgs)
+    this.oracle = new OracleClient(clientArgs)
+    this.swapper = new SwapperClient(clientArgs)
+    this.passThroughWallet = new PassThroughWalletClient(clientArgs)
+    this.splitV1 = new SplitV1Client(clientArgs)
+    this.splitV2 = new SplitV2Client(clientArgs)
+    this.warehouse = new WarehouseClient(clientArgs)
 
-    if (apiConfig) {
+    if (clientArgs.apiConfig) {
       this.dataClient = new DataClient({
-        publicClient,
-        publicClients,
-        ensPublicClient,
-        includeEnsNames,
-        apiConfig,
+        publicClient: clientArgs.publicClient,
+        publicClients: clientArgs.publicClients,
+        ensPublicClient: clientArgs.ensPublicClient,
+        includeEnsNames: clientArgs.includeEnsNames,
+        apiConfig: clientArgs.apiConfig,
       })
     }
 
-    this.estimateGas = new SplitsClientGasEstimates({
-      chainId,
-      publicClient,
-      publicClients,
-      walletClient,
-      ensPublicClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.estimateGas = new SplitsClientGasEstimates(clientArgs)
   }
 }
 
@@ -172,23 +70,11 @@ applyMixins(SplitsClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class SplitsClientGasEstimates extends BaseTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-    ensPublicClient,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
       supportedChainIds: [],
+      ...clientArgs,
     })
   }
 }

--- a/packages/splits-sdk/src/client/liquidSplit.test.ts
+++ b/packages/splits-sdk/src/client/liquidSplit.test.ts
@@ -21,7 +21,6 @@ import {
   InvalidConfigError,
   MissingPublicClientError,
   MissingWalletClientError,
-  UnsupportedChainIdError,
 } from '../errors'
 import * as utils from '../utils'
 import * as numberUtils from '../utils/numbers'
@@ -116,6 +115,9 @@ const mockWalletClient = jest.fn(() => {
     account: {
       address: CONTROLLER_ADDRESS,
     },
+    chain: {
+      id: 1,
+    },
     writeContract: jest.fn(() => {
       return '0xhash'
     }),
@@ -125,6 +127,9 @@ const mockWalletClientNonController = jest.fn(() => {
   return {
     account: {
       address: '0xnotController',
+    },
+    chain: {
+      id: 1,
     },
     writeContract: jest.fn(() => {
       return '0xhash'
@@ -137,41 +142,6 @@ describe('Client config validation', () => {
     expect(
       () => new LiquidSplitClient({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new LiquidSplitClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 1 })).not.toThrow()
-  })
-
-  test('Polygon chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 137 })).not.toThrow()
-  })
-
-  test('Optimism chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 10 })).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 42161 })).not.toThrow()
-  })
-
-  test('Zora chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 7777777 })).not.toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 8453 })).not.toThrow()
-  })
-
-  test('Other chain ids pass', () => {
-    expect(() => new LiquidSplitClient({ chainId: 100 })).not.toThrow()
-    expect(() => new LiquidSplitClient({ chainId: 56 })).not.toThrow()
   })
 })
 
@@ -229,6 +199,7 @@ describe('Liquid split writes', () => {
     test('Create liquid split fails with no provider', async () => {
       const badClient = new LiquidSplitClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -355,6 +326,7 @@ describe('Liquid split writes', () => {
     test('Distribute token fails with no provider', async () => {
       const badClient = new LiquidSplitClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -464,6 +436,7 @@ describe('Liquid split writes', () => {
     test('Transfer ownership fails with no provider', async () => {
       const badClient = new LiquidSplitClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(

--- a/packages/splits-sdk/src/client/liquidSplit.ts
+++ b/packages/splits-sdk/src/client/liquidSplit.ts
@@ -56,24 +56,10 @@ import {
 type LS1155Abi = typeof ls1155CloneAbi
 
 class LiquidSplitTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: LIQUID_SPLIT_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -218,22 +204,10 @@ export class LiquidSplitClient extends LiquidSplitTransactions {
   readonly callData: LiquidSplitCallData
   readonly estimateGas: LiquidSplitGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
 
     this.eventTopics = {
@@ -265,22 +239,8 @@ export class LiquidSplitClient extends LiquidSplitTransactions {
       ],
     }
 
-    this.callData = new LiquidSplitCallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new LiquidSplitGasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new LiquidSplitCallData(clientArgs)
+    this.estimateGas = new LiquidSplitGasEstimates(clientArgs)
   }
 
   // Write actions
@@ -540,22 +500,10 @@ applyMixins(LiquidSplitClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class LiquidSplitGasEstimates extends LiquidSplitTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -597,22 +545,10 @@ interface LiquidSplitGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(LiquidSplitGasEstimates, [BaseGasEstimatesMixin])
 
 class LiquidSplitCallData extends LiquidSplitTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/oracle.test.ts
+++ b/packages/splits-sdk/src/client/oracle.test.ts
@@ -1,11 +1,7 @@
 import { Chain, Hex, PublicClient, Transport } from 'viem'
 
 import { OracleClient } from './oracle'
-import {
-  InvalidConfigError,
-  MissingPublicClientError,
-  UnsupportedChainIdError,
-} from '../errors'
+import { InvalidConfigError, MissingPublicClientError } from '../errors'
 import { validateAddress } from '../utils/validation'
 import { readActions } from '../testing/mocks/oracle'
 import { MockViemContract } from '../testing/mocks/viemContract'
@@ -31,52 +27,6 @@ describe('Client config validation', () => {
     expect(
       () => new OracleClient({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new OracleClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new OracleClient({ chainId: 1 })).not.toThrow()
-  })
-
-  test('Polygon chain id pass', () => {
-    expect(() => new OracleClient({ chainId: 137 })).not.toThrow()
-  })
-  test('Mumbai chain id fail', () => {
-    expect(() => new OracleClient({ chainId: 80001 })).toThrow()
-  })
-
-  test('Optimism chain id pass', () => {
-    expect(() => new OracleClient({ chainId: 10 })).not.toThrow()
-  })
-  test('Optimism goerli chain id fail', () => {
-    expect(() => new OracleClient({ chainId: 420 })).toThrow()
-  })
-
-  test('Arbitrum chain ids pass (test chain fails)', () => {
-    expect(() => new OracleClient({ chainId: 42161 })).not.toThrow()
-    expect(() => new OracleClient({ chainId: 421613 })).toThrow()
-  })
-
-  test('Zora chain ids fail', () => {
-    expect(() => new OracleClient({ chainId: 7777777 })).toThrow()
-    expect(() => new OracleClient({ chainId: 999 })).toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new OracleClient({ chainId: 8453 })).not.toThrow()
-  })
-
-  test('Other chain ids fail', () => {
-    expect(() => new OracleClient({ chainId: 100 })).toThrow()
-    expect(() => new OracleClient({ chainId: 250 })).toThrow()
-    expect(() => new OracleClient({ chainId: 43114 })).toThrow()
-    expect(() => new OracleClient({ chainId: 56 })).toThrow()
-    expect(() => new OracleClient({ chainId: 1313161554 })).toThrow()
   })
 })
 

--- a/packages/splits-sdk/src/client/oracle.ts
+++ b/packages/splits-sdk/src/client/oracle.ts
@@ -20,24 +20,10 @@ import { validateAddress } from '../utils/validation'
 type UniV3OracleAbi = typeof uniV3OracleAbi
 
 class OracleTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: ORACLE_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -58,22 +44,10 @@ class OracleTransactions extends BaseTransactions {
 }
 
 export class OracleClient extends OracleTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/oracle.ts
+++ b/packages/splits-sdk/src/client/oracle.ts
@@ -10,7 +10,6 @@ import {
 import { BaseTransactions } from './base'
 import { TransactionType, ORACLE_CHAIN_IDS } from '../constants'
 import { uniV3OracleAbi } from '../constants/abi/uniV3Oracle'
-import { UnsupportedChainIdError } from '../errors'
 import type {
   QuoteParams,
   SplitsClientConfig,
@@ -38,6 +37,7 @@ class OracleTransactions extends BaseTransactions {
       walletClient,
       apiConfig,
       includeEnsNames,
+      supportedChainIds: ORACLE_CHAIN_IDS,
     })
   }
 
@@ -72,9 +72,6 @@ export class OracleClient extends OracleTransactions {
       apiConfig,
       includeEnsNames,
     })
-
-    if (!ORACLE_CHAIN_IDS.includes(chainId))
-      throw new UnsupportedChainIdError(chainId, ORACLE_CHAIN_IDS)
   }
 
   // Read actions

--- a/packages/splits-sdk/src/client/passThroughWallet.test.ts
+++ b/packages/splits-sdk/src/client/passThroughWallet.test.ts
@@ -15,7 +15,6 @@ import {
   InvalidConfigError,
   MissingPublicClientError,
   MissingWalletClientError,
-  UnsupportedChainIdError,
 } from '../errors'
 import { validateAddress } from '../utils/validation'
 import { writeActions as factoryWriteActions } from '../testing/mocks/passThroughWalletFactory'
@@ -78,6 +77,9 @@ const mockWalletClient = jest.fn(() => {
     account: {
       address: OWNER_ADDRESS,
     },
+    chain: {
+      id: 1,
+    },
     writeContract: jest.fn(() => {
       return '0xhash'
     }),
@@ -87,6 +89,9 @@ const mockWalletClientNonOwner = jest.fn(() => {
   return {
     account: {
       address: '0xnotOwner',
+    },
+    chain: {
+      id: 1,
     },
     writeContract: jest.fn(() => {
       return '0xhash'
@@ -99,41 +104,6 @@ describe('Client config validation', () => {
     expect(
       () => new PassThroughWalletClient({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 1 })).not.toThrow()
-  })
-
-  test('Polygon chain id pass', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 137 })).not.toThrow()
-  })
-
-  test('Optimism chain id pass', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 10 })).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass (test chain fails)', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 42161 })).not.toThrow()
-  })
-
-  test('Zora chain ids fail', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 7777777 })).toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 8453 })).not.toThrow()
-  })
-
-  test('Other chain ids fail', () => {
-    expect(() => new PassThroughWalletClient({ chainId: 100 })).toThrow()
-    expect(() => new PassThroughWalletClient({ chainId: 56 })).toThrow()
   })
 })
 
@@ -182,6 +152,7 @@ describe('Pass through wallet writes', () => {
     test('Create pass through wallet fails with no provider', async () => {
       const badClient = new PassThroughWalletClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -253,6 +224,7 @@ describe('Pass through wallet writes', () => {
     test('Pass through tokens fails with no provider', async () => {
       const badClient = new PassThroughWalletClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -315,6 +287,7 @@ describe('Pass through wallet writes', () => {
     test('Set pass through fails with no provider', async () => {
       const badClient = new PassThroughWalletClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -391,6 +364,7 @@ describe('Pass through wallet writes', () => {
     test('Set paused fails with no provider', async () => {
       const badClient = new PassThroughWalletClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -473,6 +447,7 @@ describe('Pass through wallet writes', () => {
     test('Exec calls fails with no provider', async () => {
       const badClient = new PassThroughWalletClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(

--- a/packages/splits-sdk/src/client/passThroughWallet.ts
+++ b/packages/splits-sdk/src/client/passThroughWallet.ts
@@ -43,24 +43,10 @@ import { validateAddress } from '../utils/validation'
 type PassThroughWalletAbi = typeof passThroughWalletAbi
 
 class PassThroughWalletTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: PASS_THROUGH_WALLET_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -221,22 +207,10 @@ export class PassThroughWalletClient extends PassThroughWalletTransactions {
   readonly callData: PassThroughWalletCallData
   readonly estimateGas: PassThroughWalletGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
 
     this.eventTopics = {
@@ -272,22 +246,8 @@ export class PassThroughWalletClient extends PassThroughWalletTransactions {
       ],
     }
 
-    this.callData = new PassThroughWalletCallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new PassThroughWalletGasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new PassThroughWalletCallData(clientArgs)
+    this.estimateGas = new PassThroughWalletGasEstimates(clientArgs)
   }
 
   // Write actions
@@ -477,22 +437,10 @@ applyMixins(PassThroughWalletClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class PassThroughWalletGasEstimates extends PassThroughWalletTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -539,22 +487,10 @@ interface PassThroughWalletGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(PassThroughWalletGasEstimates, [BaseGasEstimatesMixin])
 
 class PassThroughWalletCallData extends PassThroughWalletTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/splitV1.ts
+++ b/packages/splits-sdk/src/client/splitV1.ts
@@ -83,24 +83,10 @@ const polygonAbiChainIds = [
 type SplitMainEthereumAbiType = typeof splitMainEthereumAbi
 
 class SplitV1Transactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: SPLITS_SUPPORTED_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -572,40 +558,14 @@ export class SplitV1Client extends SplitV1Transactions {
   readonly callData: SplitV1CallData
   readonly estimateGas: SplitV1GasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-    ensPublicClient,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
 
-    this.callData = new SplitV1CallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      apiConfig,
-      walletClient,
-      includeEnsNames,
-    })
-    this.estimateGas = new SplitV1GasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      apiConfig,
-      walletClient,
-      includeEnsNames,
-    })
+    this.callData = new SplitV1CallData(clientArgs)
+    this.estimateGas = new SplitV1GasEstimates(clientArgs)
   }
 
   getEventTopics(chainId: number) {
@@ -1190,22 +1150,10 @@ applyMixins(SplitV1Client, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class SplitV1GasEstimates extends SplitV1Transactions {
-  constructor({
-    chainId,
-    publicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-    ensPublicClient,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
+      ...clientArgs,
     })
   }
 
@@ -1297,22 +1245,10 @@ interface SplitV1GasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(SplitV1GasEstimates, [BaseGasEstimatesMixin])
 
 class SplitV1CallData extends SplitV1Transactions {
-  constructor({
-    chainId,
-    publicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-    ensPublicClient,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/splitV1.ts
+++ b/packages/splits-sdk/src/client/splitV1.ts
@@ -548,12 +548,14 @@ class SplitV1Transactions extends BaseTransactions {
     SplitMainEthereumAbiType,
     PublicClient<Transport, Chain>
   > {
+    const publicClient = this._getPublicClient(chainId)
+
     return getContract({
       address: getSplitMainAddress(chainId),
       abi: splitMainEthereumAbi,
       // @ts-expect-error v1/v2 viem support
-      client: this._publicClient,
-      publicClient: this._publicClient,
+      client: publicClient,
+      publicClient: publicClient,
     })
   }
 
@@ -1068,9 +1070,8 @@ export class SplitV1Client extends SplitV1Transactions {
   }> {
     validateAddress(splitAddress)
     validateAddress(token)
-    this._requirePublicClient()
 
-    const functionChainId = chainId ?? this._chainId
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     if (!functionChainId)
       throw new InvalidArgumentError('Please pass in the chainId you are using')
 
@@ -1100,13 +1101,12 @@ export class SplitV1Client extends SplitV1Transactions {
     splitExists: boolean
   }> {
     validateSplitInputs({ recipients, distributorFeePercent })
-    this._requirePublicClient()
 
     const [accounts, percentAllocations] =
       getRecipientSortedAddressesAndAllocations(recipients)
     const distributorFee = getBigIntFromPercent(distributorFeePercent)
 
-    const functionChainId = chainId ?? this._chainId
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     if (!functionChainId)
       throw new InvalidArgumentError('Please pass in the chainId you are using')
 
@@ -1137,9 +1137,8 @@ export class SplitV1Client extends SplitV1Transactions {
     controller: Address
   }> {
     validateAddress(splitAddress)
-    this._requirePublicClient()
 
-    const functionChainId = chainId ?? this._chainId
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     if (!functionChainId)
       throw new InvalidArgumentError('Please pass in the chainId you are using')
 
@@ -1162,9 +1161,8 @@ export class SplitV1Client extends SplitV1Transactions {
     newPotentialController: Address
   }> {
     validateAddress(splitAddress)
-    this._requirePublicClient()
 
-    const functionChainId = chainId ?? this._chainId
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     if (!functionChainId)
       throw new InvalidArgumentError('Please pass in the chainId you are using')
 
@@ -1188,9 +1186,8 @@ export class SplitV1Client extends SplitV1Transactions {
     hash: string
   }> {
     validateAddress(splitAddress)
-    this._requirePublicClient()
 
-    const functionChainId = chainId ?? this._chainId
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     if (!functionChainId)
       throw new InvalidArgumentError('Please pass in the chainId you are using')
 

--- a/packages/splits-sdk/src/client/splitV1.ts
+++ b/packages/splits-sdk/src/client/splitV1.ts
@@ -142,12 +142,12 @@ class SplitV1Transactions extends BaseTransactions {
     validateAddress(splitAddress)
     validateSplitInputs({ recipients, distributorFeePercent })
 
-    const functionChainId = this._getFunctionChainId(chainId)
-
     if (this._shouldRequireWalletClient) {
       this._requireWalletClient()
-      await this._requireController(splitAddress, functionChainId)
+      await this._requireController(splitAddress)
     }
+
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const [accounts, percentAllocations] =
       getRecipientSortedAddressesAndAllocations(recipients)
@@ -248,12 +248,12 @@ class SplitV1Transactions extends BaseTransactions {
     validateAddress(token)
     validateSplitInputs({ recipients, distributorFeePercent })
 
-    const functionChainId = this._getFunctionChainId(chainId)
-
     if (this._shouldRequireWalletClient) {
       this._requireWalletClient()
-      await this._requireController(splitAddress, functionChainId)
+      await this._requireController(splitAddress)
     }
+
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const [accounts, percentAllocations] =
       getRecipientSortedAddressesAndAllocations(recipients)
@@ -328,12 +328,12 @@ class SplitV1Transactions extends BaseTransactions {
   }: InitiateControlTransferConfig): Promise<TransactionFormat> {
     validateAddress(splitAddress)
 
-    const functionChainId = this._getFunctionChainId(chainId)
-
     if (this._shouldRequireWalletClient) {
       this._requireWalletClient()
-      await this._requireController(splitAddress, functionChainId)
+      await this._requireController(splitAddress)
     }
+
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const result = await this._executeContractFunction({
       contractAddress: getSplitMainAddress(functionChainId),
@@ -353,12 +353,12 @@ class SplitV1Transactions extends BaseTransactions {
   }: CancelControlTransferConfig): Promise<TransactionFormat> {
     validateAddress(splitAddress)
 
-    const functionChainId = this._getFunctionChainId(chainId)
-
     if (this._shouldRequireWalletClient) {
       this._requireWalletClient()
-      await this._requireController(splitAddress, functionChainId)
+      await this._requireController(splitAddress)
     }
+
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const result = await this._executeContractFunction({
       contractAddress: getSplitMainAddress(functionChainId),
@@ -378,12 +378,12 @@ class SplitV1Transactions extends BaseTransactions {
   }: AcceptControlTransferConfig): Promise<TransactionFormat> {
     validateAddress(splitAddress)
 
-    const functionChainId = this._getFunctionChainId(chainId)
-
     if (this._shouldRequireWalletClient) {
       this._requireWalletClient()
-      await this._requireNewPotentialController(splitAddress, functionChainId)
+      await this._requireNewPotentialController(splitAddress)
     }
+
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const result = await this._executeContractFunction({
       contractAddress: getSplitMainAddress(functionChainId),
@@ -403,12 +403,12 @@ class SplitV1Transactions extends BaseTransactions {
   }: MakeSplitImmutableConfig): Promise<TransactionFormat> {
     validateAddress(splitAddress)
 
-    const functionChainId = this._getFunctionChainId(chainId)
-
     if (this._shouldRequireWalletClient) {
       this._requireWalletClient()
-      await this._requireController(splitAddress, functionChainId)
+      await this._requireController(splitAddress)
     }
+
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const result = await this._executeContractFunction({
       contractAddress: getSplitMainAddress(functionChainId),
@@ -510,7 +510,8 @@ class SplitV1Transactions extends BaseTransactions {
     return result
   }
 
-  private async _requireController(splitAddress: string, chainId: number) {
+  private async _requireController(splitAddress: string) {
+    const chainId = this._walletClient!.chain.id
     const splitMainContract = this._getSplitMainContract(chainId)
     const controller = await splitMainContract.read.getController([
       getAddress(splitAddress),
@@ -524,10 +525,8 @@ class SplitV1Transactions extends BaseTransactions {
       )
   }
 
-  private async _requireNewPotentialController(
-    splitAddress: string,
-    chainId: number,
-  ) {
+  private async _requireNewPotentialController(splitAddress: string) {
+    const chainId = this._walletClient!.chain.id
     const splitMainContract = this._getSplitMainContract(chainId)
     const newPotentialController =
       await splitMainContract.read.getNewPotentialController([

--- a/packages/splits-sdk/src/client/splitV1.ts
+++ b/packages/splits-sdk/src/client/splitV1.ts
@@ -33,7 +33,6 @@ import {
   splitMainPolygonAbi,
 } from '../constants/abi/splitMain'
 import {
-  InvalidArgumentError,
   InvalidAuthError,
   TransactionFailedError,
   UnsupportedChainIdError,
@@ -1071,9 +1070,6 @@ export class SplitV1Client extends SplitV1Transactions {
     validateAddress(token)
 
     const functionChainId = this._getReadOnlyFunctionChainId(chainId)
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const splitMainContract = this._getSplitMainContract(functionChainId)
 
     const balance =
@@ -1106,9 +1102,6 @@ export class SplitV1Client extends SplitV1Transactions {
     const distributorFee = getBigIntFromPercent(distributorFeePercent)
 
     const functionChainId = this._getReadOnlyFunctionChainId(chainId)
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const splitMainContract = this._getSplitMainContract(functionChainId)
 
     const splitAddress =
@@ -1138,9 +1131,6 @@ export class SplitV1Client extends SplitV1Transactions {
     validateAddress(splitAddress)
 
     const functionChainId = this._getReadOnlyFunctionChainId(chainId)
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const splitMainContract = this._getSplitMainContract(functionChainId)
 
     const controller = await splitMainContract.read.getController([
@@ -1162,9 +1152,6 @@ export class SplitV1Client extends SplitV1Transactions {
     validateAddress(splitAddress)
 
     const functionChainId = this._getReadOnlyFunctionChainId(chainId)
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const splitMainContract = this._getSplitMainContract(functionChainId)
 
     const newPotentialController =
@@ -1187,9 +1174,6 @@ export class SplitV1Client extends SplitV1Transactions {
     validateAddress(splitAddress)
 
     const functionChainId = this._getReadOnlyFunctionChainId(chainId)
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const splitMainContract = this._getSplitMainContract(functionChainId)
 
     const hash = await splitMainContract.read.getHash([

--- a/packages/splits-sdk/src/client/splitV2-fork.test.ts
+++ b/packages/splits-sdk/src/client/splitV2-fork.test.ts
@@ -12,7 +12,7 @@ import {
   parseEther,
   zeroAddress,
 } from 'viem'
-import { ChainId, getSplitV2FactoryAddress } from '../constants'
+import { getSplitV2FactoryAddress } from '../constants'
 import {
   InvalidConfigError,
   InvalidDistributorFeePercentErrorV2,
@@ -20,7 +20,6 @@ import {
   MissingPublicClientError,
   MissingWalletClientError,
   SaltRequired,
-  UnsupportedChainIdError,
 } from '../errors'
 import { SplitV2Client } from './splitV2'
 import { base, mainnet } from 'viem/chains'
@@ -36,47 +35,6 @@ describe('Client config validation', () => {
     expect(
       () => new SplitV2Client({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new SplitV2Client({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new SplitV2Client({ chainId: ChainId.MAINNET })).not.toThrow()
-    expect(() => new SplitV2Client({ chainId: ChainId.HOLESKY })).not.toThrow()
-    expect(() => new SplitV2Client({ chainId: ChainId.SEPOLIA })).not.toThrow()
-  })
-
-  test('Polygon chain ids pass', () => {
-    expect(() => new SplitV2Client({ chainId: ChainId.POLYGON })).not.toThrow()
-  })
-
-  test('Optimism chain ids pass', () => {
-    expect(() => new SplitV2Client({ chainId: ChainId.OPTIMISM })).not.toThrow()
-    expect(
-      () => new SplitV2Client({ chainId: ChainId.OPTIMISM_SEPOLIA }),
-    ).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass', () => {
-    expect(() => new SplitV2Client({ chainId: ChainId.ARBITRUM })).not.toThrow()
-  })
-
-  test('Zora chain ids pass', () => {
-    expect(() => new SplitV2Client({ chainId: ChainId.ZORA })).not.toThrow()
-    expect(
-      () => new SplitV2Client({ chainId: ChainId.ZORA_SEPOLIA }),
-    ).not.toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new SplitV2Client({ chainId: ChainId.BASE })).not.toThrow()
-    expect(
-      () => new SplitV2Client({ chainId: ChainId.BASE_SEPOLIA }),
-    ).not.toThrow()
   })
 })
 
@@ -121,6 +79,7 @@ describe('Split v2 writes', () => {
     test('fails with no provider', async () => {
       const badClient = new SplitV2Client({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -167,7 +126,9 @@ describe('Split v2 writes', () => {
       })
 
       expect(getAddress(event.address)).toEqual(
-        getAddress(getSplitV2FactoryAddress(client._chainId, SplitV2Type.Pull)),
+        getAddress(
+          getSplitV2FactoryAddress(client._chainId!, SplitV2Type.Pull),
+        ),
       )
       expect(decodedLog.eventName).toEqual('SplitCreated')
       if (decodedLog.eventName === 'SplitCreated') {
@@ -199,7 +160,9 @@ describe('Split v2 writes', () => {
       })
 
       expect(getAddress(event.address)).toEqual(
-        getAddress(getSplitV2FactoryAddress(client._chainId, SplitV2Type.Pull)),
+        getAddress(
+          getSplitV2FactoryAddress(client._chainId!, SplitV2Type.Pull),
+        ),
       )
       expect(decodedLog.eventName).toEqual('SplitCreated')
       if (decodedLog.eventName === 'SplitCreated') {
@@ -232,7 +195,9 @@ describe('Split v2 writes', () => {
       })
 
       expect(getAddress(event.address)).toEqual(
-        getAddress(getSplitV2FactoryAddress(client._chainId, SplitV2Type.Push)),
+        getAddress(
+          getSplitV2FactoryAddress(client._chainId!, SplitV2Type.Push),
+        ),
       )
       expect(decodedLog.eventName).toEqual('SplitCreated')
       if (decodedLog.eventName === 'SplitCreated') {
@@ -266,7 +231,9 @@ describe('Split v2 writes', () => {
       })
 
       expect(getAddress(event.address)).toEqual(
-        getAddress(getSplitV2FactoryAddress(client._chainId, SplitV2Type.Push)),
+        getAddress(
+          getSplitV2FactoryAddress(client._chainId!, SplitV2Type.Push),
+        ),
       )
       expect(decodedLog.eventName).toEqual('SplitCreated')
       if (decodedLog.eventName === 'SplitCreated') {
@@ -340,6 +307,7 @@ describe('Split v2 writes', () => {
     test('fails with no provider', async () => {
       const badClient = new SplitV2Client({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -402,6 +370,7 @@ describe('Split v2 writes', () => {
     test('fails with no provider', async () => {
       const badClient = new SplitV2Client({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -463,6 +432,7 @@ describe('Split v2 writes', () => {
     test('fails with no provider', async () => {
       const badClient = new SplitV2Client({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -524,6 +494,7 @@ describe('Split v2 writes', () => {
     test('fails with no provider', async () => {
       const badClient = new SplitV2Client({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -595,6 +566,7 @@ describe('Split v2 writes', () => {
     test('fails with no provider', async () => {
       const badClient = new SplitV2Client({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(

--- a/packages/splits-sdk/src/client/splitV2.ts
+++ b/packages/splits-sdk/src/client/splitV2.ts
@@ -23,7 +23,6 @@ import {
 import { splitV2ABI } from '../constants/abi/splitV2'
 import { splitV2FactoryABI } from '../constants/abi/splitV2Factory'
 import {
-  InvalidArgumentError,
   InvalidAuthError,
   SaltRequired,
   TransactionFailedError,
@@ -782,9 +781,6 @@ export class SplitV2Client extends SplitV2Transactions {
     const functionChainId = this._getReadOnlyFunctionChainId(
       createSplitArgs.chainId,
     )
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const factory = this._getSplitV2FactoryContract(
       createSplitArgs.splitType ?? SplitV2Type.Pull,
       functionChainId,
@@ -847,9 +843,6 @@ export class SplitV2Client extends SplitV2Transactions {
     const functionChainId = this._getReadOnlyFunctionChainId(
       createSplitArgs.chainId,
     )
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
-
     const factory = this._getSplitV2FactoryContract(
       createSplitArgs.splitType ?? SplitV2Type.Pull,
       functionChainId,

--- a/packages/splits-sdk/src/client/splitV2.ts
+++ b/packages/splits-sdk/src/client/splitV2.ts
@@ -62,24 +62,10 @@ const VALID_ERC1271_SIG = '0x1626ba7e'
 
 // TODO:add validation to execute contract function
 class SplitV2Transactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: SPLITS_V2_SUPPORTED_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -477,22 +463,10 @@ export class SplitV2Client extends SplitV2Transactions {
   readonly estimateGas: SplitV2GasEstimates
   readonly sign: SplitV2Signature
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
     this.eventTopics = {
       splitCreated: [
@@ -533,30 +507,9 @@ export class SplitV2Client extends SplitV2Transactions {
       ],
     }
 
-    this.callData = new SplitV2CallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new SplitV2GasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.sign = new SplitV2Signature({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new SplitV2CallData(clientArgs)
+    this.estimateGas = new SplitV2GasEstimates(clientArgs)
+    this.sign = new SplitV2Signature(clientArgs)
   }
 
   async submitCreateSplitTransaction(
@@ -989,22 +942,10 @@ applyMixins(SplitV2Client, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class SplitV2GasEstimates extends SplitV2Transactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -1058,22 +999,10 @@ interface SplitV2GasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(SplitV2GasEstimates, [BaseGasEstimatesMixin])
 
 class SplitV2CallData extends SplitV2Transactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -1123,22 +1052,10 @@ class SplitV2CallData extends SplitV2Transactions {
 }
 
 class SplitV2Signature extends SplitV2Transactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Signature,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/swapper.test.ts
+++ b/packages/splits-sdk/src/client/swapper.test.ts
@@ -15,7 +15,6 @@ import {
   InvalidConfigError,
   MissingPublicClientError,
   MissingWalletClientError,
-  UnsupportedChainIdError,
 } from '../errors'
 import * as swapperUtils from '../utils/swapper'
 import {
@@ -106,6 +105,9 @@ const mockWalletClient = jest.fn(() => {
     account: {
       address: OWNER_ADDRESS,
     },
+    chain: {
+      id: 1,
+    },
     writeContract: jest.fn(() => {
       return '0xhash'
     }),
@@ -115,6 +117,9 @@ const mockWalletClientNonOwner = jest.fn(() => {
   return {
     account: {
       address: '0xnotOwner',
+    },
+    chain: {
+      id: 1,
     },
     writeContract: jest.fn(() => {
       return '0xhash'
@@ -127,41 +132,6 @@ describe('Client config validation', () => {
     expect(
       () => new SwapperClient({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new SwapperClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new SwapperClient({ chainId: 1 })).not.toThrow()
-  })
-
-  test('Polygon chain id pass', () => {
-    expect(() => new SwapperClient({ chainId: 137 })).not.toThrow()
-  })
-
-  test('Optimism chain id pass', () => {
-    expect(() => new SwapperClient({ chainId: 10 })).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass (test chain fails)', () => {
-    expect(() => new SwapperClient({ chainId: 42161 })).not.toThrow()
-  })
-
-  test('Zora chain ids fail', () => {
-    expect(() => new SwapperClient({ chainId: 7777777 })).toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new SwapperClient({ chainId: 8453 })).not.toThrow()
-  })
-
-  test('Other chain ids fail', () => {
-    expect(() => new SwapperClient({ chainId: 100 })).toThrow()
-    expect(() => new SwapperClient({ chainId: 56 })).toThrow()
   })
 })
 
@@ -220,6 +190,7 @@ describe('Swapper writes', () => {
     test('Create swapper fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -322,6 +293,7 @@ describe('Swapper writes', () => {
     test('Set beneficiary fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -400,6 +372,7 @@ describe('Swapper writes', () => {
     test('Set token to beneficiary fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -478,6 +451,7 @@ describe('Swapper writes', () => {
     test('Set oracle fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -556,6 +530,7 @@ describe('Swapper writes', () => {
     test('Set default scale fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -654,6 +629,7 @@ describe('Swapper writes', () => {
     test('Set scale factor overrides fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -739,6 +715,7 @@ describe('Swapper writes', () => {
     test('Set paused fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -821,6 +798,7 @@ describe('Swapper writes', () => {
     test('Exec calls fails with no provider', async () => {
       const badClient = new SwapperClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(

--- a/packages/splits-sdk/src/client/swapper.ts
+++ b/packages/splits-sdk/src/client/swapper.ts
@@ -65,24 +65,10 @@ type SwapperAbi = typeof swapperAbi
 type UniV3SwapAbi = typeof uniV3SwapAbi
 
 class SwapperTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: SWAPPER_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -422,22 +408,10 @@ export class SwapperClient extends SwapperTransactions {
   readonly callData: SwapperCallData
   readonly estimateGas: SwapperGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
     this.eventTopics = {
       createSwapper: [
@@ -496,22 +470,8 @@ export class SwapperClient extends SwapperTransactions {
       ],
     }
 
-    this.callData = new SwapperCallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new SwapperGasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new SwapperCallData(clientArgs)
+    this.estimateGas = new SwapperGasEstimates(clientArgs)
   }
 
   // Write actions
@@ -923,22 +883,10 @@ applyMixins(SwapperClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class SwapperGasEstimates extends SwapperTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -1018,22 +966,10 @@ interface SwapperGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(SwapperGasEstimates, [BaseGasEstimatesMixin])
 
 class SwapperCallData extends SwapperTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/templates.test.ts
+++ b/packages/splits-sdk/src/client/templates.test.ts
@@ -13,7 +13,6 @@ import {
   InvalidConfigError,
   MissingPublicClientError,
   MissingWalletClientError,
-  UnsupportedChainIdError,
 } from '../errors'
 import * as utils from '../utils'
 import * as swapperUtils from '../utils/swapper'
@@ -109,6 +108,9 @@ const mockWalletClient = jest.fn(() => {
     account: {
       address: CONTROLLER_ADDRESS,
     },
+    chain: {
+      id: 1,
+    },
     writeContract: jest.fn(() => {
       return '0xhash'
     }),
@@ -120,41 +122,6 @@ describe('Client config validation', () => {
     expect(
       () => new TemplatesClient({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new TemplatesClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 1 })).not.toThrow()
-  })
-
-  test('Polygon chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 137 })).not.toThrow()
-  })
-
-  test('Optimism chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 10 })).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 42161 })).not.toThrow()
-  })
-
-  test('Zora chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 7777777 })).not.toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 8453 })).not.toThrow()
-  })
-
-  test('Other chain ids pass', () => {
-    expect(() => new TemplatesClient({ chainId: 100 })).not.toThrow()
-    expect(() => new TemplatesClient({ chainId: 56 })).not.toThrow()
   })
 })
 
@@ -209,6 +176,7 @@ describe('Template writes', () => {
     test('Create recoup fails with no provider', async () => {
       const badClient = new TemplatesClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(
@@ -327,6 +295,7 @@ describe('Template writes', () => {
     test('Create diversifier fails with no provider', async () => {
       const badClient = new TemplatesClient({
         chainId: 1,
+        walletClient: new mockWalletClient(),
       })
 
       await expect(

--- a/packages/splits-sdk/src/client/templates.ts
+++ b/packages/splits-sdk/src/client/templates.ts
@@ -85,17 +85,16 @@ class TemplatesTransactions extends BaseTransactions {
       nonWaterfallRecipientTrancheIndex,
     )
 
-    this._requirePublicClient()
-    if (!this._publicClient) throw new Error('Public client required')
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const functionChainId = this._getFunctionChainId(chainId)
+    const publicClient = this._getPublicClient(functionChainId)
 
     const [recoupTranches, trancheSizes] = await getRecoupTranchesAndSizes(
       functionChainId,
       getAddress(token),
       tranches,
-      this._publicClient,
+      publicClient,
     )
 
     const formattedNonWaterfallRecipientTrancheIndex =
@@ -132,8 +131,6 @@ class TemplatesTransactions extends BaseTransactions {
     validateOracleParams(oracleParams)
     validateDiversifierRecipients(recipients)
 
-    this._requirePublicClient()
-    if (!this._publicClient) throw new Error('Public client required')
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const functionChainId = this._getFunctionChainId(chainId)
@@ -232,9 +229,6 @@ export class TemplatesClient extends TemplatesTransactions {
     waterfallModuleAddress: Address
     event: Log
   }> {
-    this._requirePublicClient()
-    if (!this._publicClient) throw new Error()
-
     const { txHash } =
       await this.submitCreateRecoupTransaction(createRecoupArgs)
     const events = await this.getTransactionEvents({
@@ -277,9 +271,6 @@ export class TemplatesClient extends TemplatesTransactions {
     passThroughWalletAddress: Address
     event: Log
   }> {
-    this._requirePublicClient()
-    if (!this._publicClient) throw new Error()
-
     const { txHash } = await this.submitCreateDiversifierTransaction(
       createDiversifierArgs,
     )

--- a/packages/splits-sdk/src/client/templates.ts
+++ b/packages/splits-sdk/src/client/templates.ts
@@ -47,24 +47,10 @@ import {
 } from '../utils/validation'
 
 class TemplatesTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: TEMPLATES_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -160,22 +146,10 @@ export class TemplatesClient extends TemplatesTransactions {
   readonly callData: TemplatesCallData
   readonly estimateGas: TemplatesGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
 
     this.eventTopics = {
@@ -194,22 +168,8 @@ export class TemplatesClient extends TemplatesTransactions {
       ],
     }
 
-    this.callData = new TemplatesCallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new TemplatesGasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new TemplatesCallData(clientArgs)
+    this.estimateGas = new TemplatesGasEstimates(clientArgs)
   }
 
   // Write actions
@@ -301,22 +261,10 @@ applyMixins(TemplatesClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class TemplatesGasEstimates extends TemplatesTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -344,22 +292,10 @@ interface TemplatesGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(TemplatesGasEstimates, [BaseGasEstimatesMixin])
 
 class TemplatesCallData extends TemplatesTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/vesting.ts
+++ b/packages/splits-sdk/src/client/vesting.ts
@@ -74,10 +74,7 @@ class VestingTransactions extends BaseTransactions {
 
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
-    const functionChainId =
-      this._walletClient?.chain.id ?? chainId ?? this._chainId
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const result = await this._executeContractFunction({
       contractAddress: getVestingFactoryAddress(functionChainId),

--- a/packages/splits-sdk/src/client/vesting.ts
+++ b/packages/splits-sdk/src/client/vesting.ts
@@ -43,24 +43,10 @@ type VestingAbi = typeof vestingAbi
 type VestingFactoryAbi = typeof vestingFactoryAbi
 
 class VestingTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: VESTING_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -161,22 +147,10 @@ export class VestingClient extends VestingTransactions {
   readonly callData: VestingCallData
   readonly estimateGas: VestingGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
 
     this.eventTopics = {
@@ -200,22 +174,8 @@ export class VestingClient extends VestingTransactions {
       ],
     }
 
-    this.callData = new VestingCallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new VestingGasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new VestingCallData(clientArgs)
+    this.estimateGas = new VestingGasEstimates(clientArgs)
   }
 
   // Write actions
@@ -425,22 +385,10 @@ applyMixins(VestingClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class VestingGasEstimates extends VestingTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -477,22 +425,10 @@ interface VestingGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(VestingGasEstimates, [BaseGasEstimatesMixin])
 
 class VestingCallData extends VestingTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/warehouse-fork.test.ts
+++ b/packages/splits-sdk/src/client/warehouse-fork.test.ts
@@ -12,12 +12,10 @@ import {
   parseEther,
   zeroAddress,
 } from 'viem'
-import { ChainId } from '../constants'
 import {
   InvalidConfigError,
   MissingPublicClientError,
   MissingWalletClientError,
-  UnsupportedChainIdError,
 } from '../errors'
 import { WarehouseClient } from './warehouse'
 import { base, foundry, mainnet } from 'viem/chains'
@@ -36,59 +34,6 @@ describe('Client config validation', () => {
     expect(
       () => new WarehouseClient({ chainId: 1, includeEnsNames: true }),
     ).toThrow(InvalidConfigError)
-  })
-
-  test('Invalid chain id fails', () => {
-    expect(() => new WarehouseClient({ chainId: 51 })).toThrow(
-      UnsupportedChainIdError,
-    )
-  })
-
-  test('Ethereum chain ids pass', () => {
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.MAINNET }),
-    ).not.toThrow()
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.HOLESKY }),
-    ).not.toThrow()
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.SEPOLIA }),
-    ).not.toThrow()
-  })
-
-  test('Polygon chain ids pass', () => {
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.POLYGON }),
-    ).not.toThrow()
-  })
-
-  test('Optimism chain ids pass', () => {
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.OPTIMISM }),
-    ).not.toThrow()
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.OPTIMISM_SEPOLIA }),
-    ).not.toThrow()
-  })
-
-  test('Arbitrum chain ids pass', () => {
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.ARBITRUM }),
-    ).not.toThrow()
-  })
-
-  test('Zora chain ids pass', () => {
-    expect(() => new WarehouseClient({ chainId: ChainId.ZORA })).not.toThrow()
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.ZORA_SEPOLIA }),
-    ).not.toThrow()
-  })
-
-  test('Base chain ids pass', () => {
-    expect(() => new WarehouseClient({ chainId: ChainId.BASE })).not.toThrow()
-    expect(
-      () => new WarehouseClient({ chainId: ChainId.BASE_SEPOLIA }),
-    ).not.toThrow()
   })
 })
 
@@ -115,6 +60,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -193,6 +139,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -273,6 +220,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -337,6 +285,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -394,6 +343,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -447,6 +397,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -496,6 +447,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -553,6 +505,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -635,6 +588,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -696,6 +650,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -764,6 +719,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -829,6 +785,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -902,6 +859,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -975,6 +933,7 @@ describe('Warehouse writes', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1042,6 +1001,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1067,6 +1027,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1092,6 +1053,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1117,6 +1079,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1143,6 +1106,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1170,6 +1134,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(async () => await badClient.eip712Domain()).rejects.toThrow(
@@ -1190,6 +1155,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1217,6 +1183,7 @@ describe('Warehouse reads', () => {
     test('fails with no provider', async () => {
       const badClient = new WarehouseClient({
         chainId: 1,
+        walletClient: walletClient(ALICE),
       })
 
       await expect(
@@ -1243,6 +1210,7 @@ describe('Warehouse reads', () => {
       test('fails with no provider', async () => {
         const badClient = new WarehouseClient({
           chainId: 1,
+          walletClient: walletClient(ALICE),
         })
 
         await expect(

--- a/packages/splits-sdk/src/client/warehouse.ts
+++ b/packages/splits-sdk/src/client/warehouse.ts
@@ -559,7 +559,7 @@ export class WarehouseClient extends WarehouseTransactions {
   }> {
     validateAddress(tokenAddress)
 
-    const functionChainId = this._getFunctionChainId(chainId)
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     const name = await this._getWarehouseContract(functionChainId).read.name([
       fromHex(tokenAddress, 'bigint'),
     ])

--- a/packages/splits-sdk/src/client/warehouse.ts
+++ b/packages/splits-sdk/src/client/warehouse.ts
@@ -58,24 +58,10 @@ const nativeTokenAddress: Address = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 class WarehouseTransactions extends BaseTransactions {
   protected readonly _warehouseAbi
 
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: SPLITS_V2_SUPPORTED_CHAIN_IDS,
+      ...transactionClientArgs,
     })
 
     this._warehouseAbi = warehouseAbi
@@ -465,22 +451,10 @@ export class WarehouseClient extends WarehouseTransactions {
   readonly estimateGas: WarehouseGasEstimates
   readonly sign: WarehouseSignature
 
-  constructor({
-    chainId,
-    publicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-    ensPublicClient,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
+      ...clientArgs,
     })
 
     this.eventTopics = {
@@ -522,32 +496,9 @@ export class WarehouseClient extends WarehouseTransactions {
       ],
     }
 
-    this.callData = new WarehouseCallData({
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
-    })
-
-    this.estimateGas = new WarehouseGasEstimates({
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
-    })
-
-    this.sign = new WarehouseSignature({
-      chainId,
-      publicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-      ensPublicClient,
-    })
+    this.callData = new WarehouseCallData(clientArgs)
+    this.estimateGas = new WarehouseGasEstimates(clientArgs)
+    this.sign = new WarehouseSignature(clientArgs)
   }
 
   // ERC6909 Metadata
@@ -1072,22 +1023,10 @@ applyMixins(WarehouseClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class WarehouseGasEstimates extends WarehouseTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -1233,22 +1172,10 @@ interface WarehouseGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(WarehouseGasEstimates, [BaseGasEstimatesMixin])
 
 class WarehouseCallData extends WarehouseTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -1390,22 +1317,10 @@ class WarehouseCallData extends WarehouseTransactions {
 }
 
 class WarehouseSignature extends WarehouseTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Signature,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/warehouse.ts
+++ b/packages/splits-sdk/src/client/warehouse.ts
@@ -46,7 +46,7 @@ import {
   SPLITS_V2_SUPPORTED_CHAIN_IDS,
   getWarehouseAddress,
 } from '../constants'
-import { TransactionFailedError, UnsupportedChainIdError } from '../errors'
+import { TransactionFailedError } from '../errors'
 import { applyMixins } from './mixin'
 import { getNumberFromPercent, validateAddress } from '../utils'
 
@@ -78,6 +78,7 @@ class WarehouseTransactions extends BaseTransactions {
       walletClient,
       apiConfig,
       includeEnsNames,
+      supportedChainIds: SPLITS_V2_SUPPORTED_CHAIN_IDS,
     })
 
     this._warehouseContract = getContract({
@@ -492,9 +493,6 @@ export class WarehouseClient extends WarehouseTransactions {
       includeEnsNames,
       ensPublicClient,
     })
-
-    if (!SPLITS_V2_SUPPORTED_CHAIN_IDS.includes(chainId))
-      throw new UnsupportedChainIdError(chainId, SPLITS_V2_SUPPORTED_CHAIN_IDS)
 
     this.eventTopics = {
       transfer: [

--- a/packages/splits-sdk/src/client/warehouse.ts
+++ b/packages/splits-sdk/src/client/warehouse.ts
@@ -21,6 +21,7 @@ import {
 } from './base'
 import {
   CallData,
+  ReadContractArgs,
   SplitsClientConfig,
   TransactionConfig,
   TransactionFormat,
@@ -56,10 +57,6 @@ const nativeTokenAddress: Address = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 
 class WarehouseTransactions extends BaseTransactions {
   protected readonly _warehouseAbi
-  protected readonly _warehouseContract: GetContractReturnType<
-    WarehouseAbiType,
-    PublicClient<Transport, Chain>
-  >
 
   constructor({
     transactionType,
@@ -81,13 +78,18 @@ class WarehouseTransactions extends BaseTransactions {
       supportedChainIds: SPLITS_V2_SUPPORTED_CHAIN_IDS,
     })
 
-    this._warehouseContract = getContract({
+    this._warehouseAbi = warehouseAbi
+  }
+
+  protected _getWarehouseContract(
+    chainId: number,
+  ): GetContractReturnType<WarehouseAbiType, PublicClient<Transport, Chain>> {
+    const publicClient = this._getPublicClient(chainId)
+    return getContract({
       address: getWarehouseAddress(),
       abi: warehouseAbi,
-      publicClient: this._publicClient,
+      publicClient: publicClient,
     })
-
-    this._warehouseAbi = warehouseAbi
   }
 
   protected async _transfer({
@@ -99,11 +101,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(receiver)
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'transfer',
       functionArgs: [receiver, fromHex(token, 'bigint'), amount],
@@ -124,11 +125,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(receiver)
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'transferFrom',
       functionArgs: [sender, receiver, fromHex(token, 'bigint'), amount],
@@ -147,11 +147,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(spender)
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'approve',
       functionArgs: [spender, fromHex(token, 'bigint'), amount],
@@ -168,11 +167,10 @@ class WarehouseTransactions extends BaseTransactions {
   }: WarehouseSetOperatorConfig): Promise<TransactionFormat> {
     validateAddress(operator)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'setOperator',
       functionArgs: [operator, approved],
@@ -186,11 +184,10 @@ class WarehouseTransactions extends BaseTransactions {
     nonce,
     transactionOverrides = {},
   }: WarehouseInvalidateNonceConfig): Promise<TransactionFormat> {
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'invalidateNonce',
       functionArgs: [nonce],
@@ -213,11 +210,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(token)
     validateAddress(target)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'temporaryApproveAndCall',
       functionArgs: [
@@ -252,11 +248,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(token)
     validateAddress(target)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'temporaryApproveAndCallBySig',
       functionArgs: [
@@ -292,11 +287,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(spender)
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'approveBySig',
       functionArgs: [
@@ -324,11 +318,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(receiver)
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'deposit',
       functionArgs: [receiver, token, amount],
@@ -348,11 +341,10 @@ class WarehouseTransactions extends BaseTransactions {
     receivers.map((receiver) => validateAddress(receiver))
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'batchDeposit',
       functionArgs: [receivers, token, amounts],
@@ -371,11 +363,10 @@ class WarehouseTransactions extends BaseTransactions {
     validateAddress(owner)
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'withdraw',
       functionArgs: [owner, token],
@@ -396,11 +387,10 @@ class WarehouseTransactions extends BaseTransactions {
     tokens.map((token) => validateAddress(token))
     validateAddress(withdrawer)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'withdraw',
       functionArgs: [owner, tokens, amounts, withdrawer],
@@ -419,11 +409,10 @@ class WarehouseTransactions extends BaseTransactions {
     receivers.map((receiver) => validateAddress(receiver))
     validateAddress(token)
 
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'batchTransfer',
       functionArgs: [receivers, token, amounts],
@@ -438,11 +427,10 @@ class WarehouseTransactions extends BaseTransactions {
     paused,
     transactionOverrides = {},
   }: WarehouseSetWithdrawConfig): Promise<TransactionFormat> {
-    this._requirePublicClient()
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
     const result = await this._executeContractFunction({
-      contractAddress: this._warehouseContract.address,
+      contractAddress: getWarehouseAddress(),
       contractAbi: warehouseAbi,
       functionName: 'setWithdrawConfig',
       functionArgs: [{ incentive: getNumberFromPercent(incentive), paused }],
@@ -452,10 +440,11 @@ class WarehouseTransactions extends BaseTransactions {
     return result
   }
 
-  protected async _eip712Domain(): Promise<{ domain: TypedDataDomain }> {
-    this._requirePublicClient()
-
-    const eip712Domain = await this._warehouseContract.read.eip712Domain()
+  protected async _eip712Domain(
+    chainId: number,
+  ): Promise<{ domain: TypedDataDomain }> {
+    const eip712Domain =
+      await this._getWarehouseContract(chainId).read.eip712Domain()
 
     return {
       domain: {
@@ -562,14 +551,16 @@ export class WarehouseClient extends WarehouseTransactions {
   }
 
   // ERC6909 Metadata
-  async getName({ tokenAddress }: { tokenAddress: Address }): Promise<{
+  async getName({
+    tokenAddress,
+    chainId,
+  }: ReadContractArgs & { tokenAddress: Address }): Promise<{
     name: string
   }> {
     validateAddress(tokenAddress)
 
-    this._requirePublicClient()
-
-    const name = await this._warehouseContract.read.name([
+    const functionChainId = this._getFunctionChainId(chainId)
+    const name = await this._getWarehouseContract(functionChainId).read.name([
       fromHex(tokenAddress, 'bigint'),
     ])
 
@@ -578,32 +569,38 @@ export class WarehouseClient extends WarehouseTransactions {
     }
   }
 
-  async getSymbol({ tokenAddress }: { tokenAddress: Address }): Promise<{
+  async getSymbol({
+    tokenAddress,
+    chainId,
+  }: ReadContractArgs & { tokenAddress: Address }): Promise<{
     symbol: string
   }> {
     validateAddress(tokenAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const symbol = await this._warehouseContract.read.symbol([
-      fromHex(tokenAddress, 'bigint'),
-    ])
+    const symbol = await this._getWarehouseContract(
+      functionChainId,
+    ).read.symbol([fromHex(tokenAddress, 'bigint')])
 
     return {
       symbol,
     }
   }
 
-  async getDecimals({ tokenAddress }: { tokenAddress: Address }): Promise<{
+  async getDecimals({
+    tokenAddress,
+    chainId,
+  }: ReadContractArgs & { tokenAddress: Address }): Promise<{
     decimals: number
   }> {
     validateAddress(tokenAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const decimals = await this._warehouseContract.read.decimals([
-      fromHex(tokenAddress, 'bigint'),
-    ])
+    const decimals = await this._getWarehouseContract(
+      functionChainId,
+    ).read.decimals([fromHex(tokenAddress, 'bigint')])
 
     return {
       decimals,
@@ -613,16 +610,17 @@ export class WarehouseClient extends WarehouseTransactions {
   // Warehouse withdraw config
   async getWithdrawConfig({
     userAddress,
-  }: {
+    chainId,
+  }: ReadContractArgs & {
     userAddress: Address
   }): Promise<{ withdrawConfig: { incentive: number; paused: boolean } }> {
     validateAddress(userAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const config = await this._warehouseContract.read.withdrawConfig([
-      userAddress,
-    ])
+    const config = await this._getWarehouseContract(
+      functionChainId,
+    ).read.withdrawConfig([userAddress])
 
     return {
       withdrawConfig: {
@@ -636,45 +634,48 @@ export class WarehouseClient extends WarehouseTransactions {
   async isValidNonce({
     userAddress,
     userNonce,
-  }: {
+    chainId,
+  }: ReadContractArgs & {
     userAddress: Address
     userNonce: bigint
   }): Promise<{ isValidNonce: boolean }> {
     validateAddress(userAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const isValidNonce = await this._warehouseContract.read.isValidNonce([
-      userAddress,
-      userNonce,
-    ])
+    const isValidNonce = await this._getWarehouseContract(
+      functionChainId,
+    ).read.isValidNonce([userAddress, userNonce])
 
     return {
       isValidNonce,
     }
   }
 
-  async eip712Domain(): Promise<{ domain: TypedDataDomain }> {
-    return this._eip712Domain()
+  async eip712Domain({
+    chainId,
+  }: ReadContractArgs): Promise<{ domain: TypedDataDomain }> {
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
+    return this._eip712Domain(functionChainId)
   }
 
   // ERC6909 read
   async isOperator({
     ownerAddress,
     operatorAddress,
-  }: {
+    chainId,
+  }: ReadContractArgs & {
     ownerAddress: Address
     operatorAddress: Address
   }): Promise<{ isOperator: boolean }> {
     validateAddress(ownerAddress)
     validateAddress(operatorAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const isOperator = await this._warehouseContract.read.isOperator([
-      ownerAddress,
-      operatorAddress,
-    ])
+    const isOperator = await this._getWarehouseContract(
+      functionChainId,
+    ).read.isOperator([ownerAddress, operatorAddress])
 
     return {
       isOperator,
@@ -684,19 +685,19 @@ export class WarehouseClient extends WarehouseTransactions {
   async balanceOf({
     ownerAddress,
     tokenAddress,
-  }: {
+    chainId,
+  }: ReadContractArgs & {
     ownerAddress: Address
     tokenAddress: Address
   }): Promise<{ balance: bigint }> {
     validateAddress(ownerAddress)
     validateAddress(tokenAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const balance = await this._warehouseContract.read.balanceOf([
-      ownerAddress,
-      fromHex(tokenAddress, 'bigint'),
-    ])
+    const balance = await this._getWarehouseContract(
+      functionChainId,
+    ).read.balanceOf([ownerAddress, fromHex(tokenAddress, 'bigint')])
 
     return {
       balance,
@@ -707,7 +708,8 @@ export class WarehouseClient extends WarehouseTransactions {
     ownerAddress,
     spenderAddress,
     tokenAddress,
-  }: {
+    chainId,
+  }: ReadContractArgs & {
     ownerAddress: Address
     spenderAddress: Address
     tokenAddress: Address
@@ -716,9 +718,11 @@ export class WarehouseClient extends WarehouseTransactions {
     validateAddress(spenderAddress)
     validateAddress(tokenAddress)
 
-    this._requirePublicClient()
+    const functionChainId = this._getReadOnlyFunctionChainId(chainId)
 
-    const allowance = await this._warehouseContract.read.allowance([
+    const allowance = await this._getWarehouseContract(
+      functionChainId,
+    ).read.allowance([
       ownerAddress,
       spenderAddress,
       fromHex(tokenAddress, 'bigint'),
@@ -1409,17 +1413,18 @@ class WarehouseSignature extends WarehouseTransactions {
   ): Promise<WarehouseApproveBySigConfig> {
     validateAddress(approveBySigArgs.spenderAddress)
     validateAddress(approveBySigArgs.tokenAddress)
+    this._requireWalletClient()
 
-    const { domain } = await this._eip712Domain()
+    const { domain } = await this._eip712Domain(this._walletClient!.chain.id)
 
     this._requireWalletClient()
 
-    const signature = await this._walletClient?.signTypedData({
+    const signature = await this._walletClient!.signTypedData({
       domain,
       types: SigTypes,
       primaryType: 'ERC6909XApproveAndCall',
       message: {
-        owner: this._walletClient.account.address,
+        owner: this._walletClient!.account.address,
         spender: approveBySigArgs.spenderAddress,
         temporary: false,
         operator: approveBySigArgs.operator,
@@ -1435,7 +1440,7 @@ class WarehouseSignature extends WarehouseTransactions {
     if (!signature) throw new Error('Error in signing data')
 
     return {
-      ownerAddress: this._walletClient?.account.address as Address,
+      ownerAddress: this._walletClient!.account.address as Address,
       signature,
       ...approveBySigArgs,
     }
@@ -1447,17 +1452,16 @@ class WarehouseSignature extends WarehouseTransactions {
     validateAddress(temporaryApproveAndCallBySigArgs.spenderAddress)
     validateAddress(temporaryApproveAndCallBySigArgs.tokenAddress)
     validateAddress(temporaryApproveAndCallBySigArgs.targetAddress)
-
-    const { domain } = await this._eip712Domain()
-
     this._requireWalletClient()
 
-    const signature = await this._walletClient?.signTypedData({
+    const { domain } = await this._eip712Domain(this._walletClient!.chain.id)
+
+    const signature = await this._walletClient!.signTypedData({
       domain,
       types: SigTypes,
       primaryType: 'ERC6909XApproveAndCall',
       message: {
-        owner: this._walletClient.account.address,
+        owner: this._walletClient!.account.address,
         spender: temporaryApproveAndCallBySigArgs.spenderAddress,
         temporary: true,
         operator: temporaryApproveAndCallBySigArgs.operator,
@@ -1473,7 +1477,7 @@ class WarehouseSignature extends WarehouseTransactions {
     if (!signature) throw new Error('Error in signing data')
 
     return {
-      ownerAddress: this._walletClient?.account.address as Address,
+      ownerAddress: this._walletClient!.account.address as Address,
       signature,
       ...temporaryApproveAndCallBySigArgs,
     }

--- a/packages/splits-sdk/src/client/warehouse.ts
+++ b/packages/splits-sdk/src/client/warehouse.ts
@@ -652,9 +652,10 @@ export class WarehouseClient extends WarehouseTransactions {
     }
   }
 
-  async eip712Domain({
-    chainId,
-  }: ReadContractArgs): Promise<{ domain: TypedDataDomain }> {
+  async eip712Domain(
+    args?: ReadContractArgs,
+  ): Promise<{ domain: TypedDataDomain }> {
+    const chainId = args?.chainId
     const functionChainId = this._getReadOnlyFunctionChainId(chainId)
     return this._eip712Domain(functionChainId)
   }

--- a/packages/splits-sdk/src/client/waterfall.ts
+++ b/packages/splits-sdk/src/client/waterfall.ts
@@ -45,24 +45,10 @@ import { validateAddress, validateWaterfallTranches } from '../utils/validation'
 type WaterfallAbi = typeof waterfallAbi
 
 class WaterfallTransactions extends BaseTransactions {
-  constructor({
-    transactionType,
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig & TransactionConfig) {
+  constructor(transactionClientArgs: SplitsClientConfig & TransactionConfig) {
     super({
-      transactionType,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
       supportedChainIds: WATERFALL_CHAIN_IDS,
+      ...transactionClientArgs,
     })
   }
 
@@ -249,22 +235,10 @@ export class WaterfallClient extends WaterfallTransactions {
   readonly callData: WaterfallCallData
   readonly estimateGas: WaterfallGasEstimates
 
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.Transaction,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
     this.eventTopics = {
       createWaterfallModule: [
@@ -293,22 +267,8 @@ export class WaterfallClient extends WaterfallTransactions {
       ],
     }
 
-    this.callData = new WaterfallCallData({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
-    this.estimateGas = new WaterfallGasEstimates({
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
-    })
+    this.callData = new WaterfallCallData(clientArgs)
+    this.estimateGas = new WaterfallGasEstimates(clientArgs)
   }
 
   // Write actions
@@ -596,22 +556,10 @@ applyMixins(WaterfallClient, [BaseClientMixin])
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 class WaterfallGasEstimates extends WaterfallTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.GasEstimate,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 
@@ -660,22 +608,10 @@ interface WaterfallGasEstimates extends BaseGasEstimatesMixin {}
 applyMixins(WaterfallGasEstimates, [BaseGasEstimatesMixin])
 
 class WaterfallCallData extends WaterfallTransactions {
-  constructor({
-    chainId,
-    publicClient,
-    ensPublicClient,
-    walletClient,
-    apiConfig,
-    includeEnsNames = false,
-  }: SplitsClientConfig) {
+  constructor(clientArgs: SplitsClientConfig) {
     super({
       transactionType: TransactionType.CallData,
-      chainId,
-      publicClient,
-      ensPublicClient,
-      walletClient,
-      apiConfig,
-      includeEnsNames,
+      ...clientArgs,
     })
   }
 

--- a/packages/splits-sdk/src/client/waterfall.ts
+++ b/packages/splits-sdk/src/client/waterfall.ts
@@ -79,10 +79,7 @@ class WaterfallTransactions extends BaseTransactions {
     if (!this._publicClient) throw new Error('Public client required')
     if (this._shouldRequireWalletClient) this._requireWalletClient()
 
-    const functionChainId =
-      this._walletClient?.chain.id ?? chainId ?? this._chainId
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
+    const functionChainId = this._getFunctionChainId(chainId)
 
     const formattedToken = getAddress(token)
     const formattedNonWaterfallRecipient = getAddress(nonWaterfallRecipient)
@@ -140,10 +137,7 @@ class WaterfallTransactions extends BaseTransactions {
     validateAddress(recipient)
     this._requireWalletClient()
 
-    const functionChainId =
-      this._walletClient?.chain.id ?? chainId ?? this._chainId
-    if (!functionChainId)
-      throw new InvalidArgumentError('Please pass in the chainId you are using')
+    const functionChainId = this._getFunctionChainId(chainId)
 
     await this._validateRecoverTokensWaterfallData({
       waterfallModuleAddress,

--- a/packages/splits-sdk/src/constants/index.ts
+++ b/packages/splits-sdk/src/constants/index.ts
@@ -154,7 +154,7 @@ export const ZORA_CHAIN_IDS = [ChainId.ZORA, ChainId.ZORA_SEPOLIA]
 export const BASE_CHAIN_IDS = [ChainId.BASE, ChainId.BASE_SEPOLIA]
 export const BLAST_CHAIN_IDS = [ChainId.BLAST]
 
-const ALL_CHAIN_IDS = [
+export const ALL_CHAIN_IDS = [
   ...ETHEREUM_CHAIN_IDS,
   ...ETHEREUM_TEST_CHAIN_IDS,
   ...POLYGON_CHAIN_IDS,

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -394,6 +394,7 @@ export type CreateRecoupConfig = {
   tranches: RecoupTrancheInput[]
   nonWaterfallRecipientAddress?: string
   nonWaterfallRecipientTrancheIndex?: number
+  chainId?: number
 } & TransactionOverridesDict
 
 // Pass through wallet
@@ -528,6 +529,7 @@ export type CreateDiversifierConfig = {
   paused?: boolean
   oracleParams: ParseOracleParams
   recipients: DiversifierRecipient[]
+  chainId?: number
 } & TransactionOverridesDict
 
 // OUTPUTS

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -324,6 +324,7 @@ export type CreateWaterfallConfig = {
   token: string
   tranches: WaterfallTrancheInput[]
   nonWaterfallRecipient?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type WaterfallFundsConfig = {
@@ -335,6 +336,7 @@ export type RecoverNonWaterfallFundsConfig = {
   waterfallModuleAddress: string
   token: string
   recipient?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type WithdrawWaterfallPullFundsConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -348,6 +348,7 @@ export type WithdrawWaterfallPullFundsConfig = {
 export type CreateVestingConfig = {
   beneficiary: string
   vestingPeriodSeconds: number
+  chainId?: number
 } & TransactionOverridesDict
 
 export type StartVestConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -49,6 +49,9 @@ export type DataClientConfig = {
 export type SplitsClientConfig = {
   chainId?: number
   publicClient?: PublicClient<Transport, Chain>
+  publicClients?: {
+    [chainId: number]: PublicClient<Transport, Chain>
+  }
   walletClient?: WalletClient<Transport, Chain, Account>
   apiConfig?: ApiConfig
   includeEnsNames?: boolean

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -38,6 +38,9 @@ export type ApiConfig = {
 
 export type DataClientConfig = {
   publicClient?: PublicClient<Transport, Chain>
+  publicClients?: {
+    [chainId: number]: PublicClient<Transport, Chain>
+  }
   apiConfig: ApiConfig
   includeEnsNames?: boolean
   // ensPublicClient can be used to fetch ens names when publicClient is not on mainnet (reverseRecords

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -416,6 +416,7 @@ export type CreatePassThroughWalletConfig = {
   owner: string
   paused?: boolean
   passThrough: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type PassThroughTokensConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -47,7 +47,7 @@ export type DataClientConfig = {
 
 // Splits
 export type SplitsClientConfig = {
-  chainId: number
+  chainId?: number
   publicClient?: PublicClient<Transport, Chain>
   walletClient?: WalletClient<Transport, Chain, Account>
   apiConfig?: ApiConfig
@@ -55,6 +55,10 @@ export type SplitsClientConfig = {
   // ensPublicClient can be used to fetch ens names when publicClient is not on mainnet (reverseRecords
   // only works on mainnet).
   ensPublicClient?: PublicClient<Transport, Chain>
+}
+
+export type BaseClientConfig = SplitsClientConfig & {
+  supportedChainIds: number[]
 }
 
 export type TransactionConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -73,6 +73,10 @@ export type SplitRecipient = {
   percentAllocation: number
 }
 
+export type ReadContractArgs = {
+  chainId?: number
+}
+
 export type CreateSplitConfig = {
   recipients: SplitRecipient[]
   distributorFeePercent: number

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -280,6 +280,7 @@ export type CreateSplitV2Config = {
   ownerAddress?: Address
   creatorAddress?: Address
   salt?: Hex
+  chainId?: number
 } & TransactionOverridesDict
 
 export type UpdateSplitV2Config = {
@@ -293,6 +294,7 @@ export type DistributeSplitConfig = {
   splitAddress: Address
   tokenAddress: Address
   distributorAddress?: Address
+  chainId?: number
 } & TransactionOverridesDict
 
 export type TransferOwnershipConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -380,12 +380,14 @@ export type CreateLiquidSplitConfig = {
   recipients: SplitRecipient[]
   distributorFeePercent: number
   owner?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type DistributeLiquidSplitTokenConfig = {
   liquidSplitAddress: string
   token: string
   distributorAddress?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type TransferLiquidSplitOwnershipConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -476,6 +476,7 @@ export type UniV3FlashSwapConfig = {
     amountOutMin: bigint
   }[]
   transactionTimeLimit?: number
+  chainId?: number
 } & TransactionOverridesDict
 
 export type SwapperExecCallsConfig = {

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -74,18 +74,21 @@ export type CreateSplitConfig = {
   recipients: SplitRecipient[]
   distributorFeePercent: number
   controller?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type UpdateSplitConfig = {
   splitAddress: string
   recipients: SplitRecipient[]
   distributorFeePercent: number
+  chainId?: number
 } & TransactionOverridesDict
 
 export type DistributeTokenConfig = {
   splitAddress: string
   token: string
   distributorAddress?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type UpdateSplitAndDistributeTokenConfig = {
@@ -94,28 +97,34 @@ export type UpdateSplitAndDistributeTokenConfig = {
   recipients: SplitRecipient[]
   distributorFeePercent: number
   distributorAddress?: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type WithdrawFundsConfig = {
   address: string
   tokens: string[]
+  chainId?: number
 } & TransactionOverridesDict
 
 export type InitiateControlTransferConfig = {
   splitAddress: string
   newController: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type CancelControlTransferConfig = {
   splitAddress: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type AcceptControlTransferConfig = {
   splitAddress: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type MakeSplitImmutableConfig = {
   splitAddress: string
+  chainId?: number
 } & TransactionOverridesDict
 
 export type BatchDistributeAndWithdrawConfig = {
@@ -123,17 +132,20 @@ export type BatchDistributeAndWithdrawConfig = {
   tokens: string[]
   recipientAddresses: string[]
   distributorAddress?: string
+  chainId?: number
 }
 
 export type BatchDistributeAndWithdrawForAllConfig = {
   splitAddress: string
   tokens: string[]
   distributorAddress?: string
+  chainId?: number
 }
 
 export type GetSplitBalanceConfig = {
   splitAddress: string
   token?: string
+  chainId?: number
 }
 
 // Warehouse

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.4
+        specifier: ^4.1.0-beta.0
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-alpha.4
+        specifier: ^2.1.0-beta.0
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.4
+        specifier: ^4.1.0-beta.0
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.1
+        specifier: ^4.1.0-alpha.2
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-alpha.1
+        specifier: ^2.1.0-alpha.2
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.1
+        specifier: ^4.1.0-alpha.2
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.3
+        specifier: ^4.1.0-alpha.4
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-alpha.3
+        specifier: ^2.1.0-alpha.4
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.3
+        specifier: ^4.1.0-alpha.4
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-beta.0
+        specifier: ^4.1.0-beta.1
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-beta.0
+        specifier: ^2.1.0-beta.1
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-beta.0
+        specifier: ^4.1.0-beta.1
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.2
+        specifier: ^4.1.0-alpha.3
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-alpha.2
+        specifier: ^2.1.0-alpha.3
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.2
+        specifier: ^4.1.0-alpha.3
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.0
+        specifier: ^4.1.0-alpha.1
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-alpha.0
+        specifier: ^2.1.0-alpha.1
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-alpha.0
+        specifier: ^4.1.0-alpha.1
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-beta.1
+        specifier: ^4.1.0-beta.2
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.1.0-beta.1
+        specifier: ^2.1.0-beta.2
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.1.0-beta.1
+        specifier: ^4.1.0-beta.2
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,10 +59,10 @@ importers:
   packages/splits-kit:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.0.4
+        specifier: ^4.1.0-alpha.0
         version: link:../splits-sdk
       '@0xsplits/splits-sdk-react':
-        specifier: ^2.0.5
+        specifier: ^2.1.0-alpha.0
         version: link:../splits-sdk-react
       '@headlessui/react':
         specifier: ^1.7.17
@@ -199,7 +199,7 @@ importers:
   packages/splits-sdk-react:
     dependencies:
       '@0xsplits/splits-sdk':
-        specifier: ^4.0.4
+        specifier: ^4.1.0-alpha.0
         version: link:../splits-sdk
       react:
         specifier: 17.x.x || 18.x.x


### PR DESCRIPTION
This is intended to be a non-breaking change.

1. Make `chainId` optional in the constructor. Any function that needs a chainId now takes it in as an optional argument. When submitting a transaction, we'll use the chainId of the walletClient if it's needed.
2. Make `publicClients` a new optional field on the constructor. It's a mapping of chainId --> public client. If that is supplied for a chain we are using, we'll use that public client. Otherwise fall back to the old (now deprecated) `publicClient` field.