### PR TITLE
fix ownership calculation

### DIFF
--- a/packages/splits-sdk/src/subgraph/split.ts
+++ b/packages/splits-sdk/src/subgraph/split.ts
@@ -178,6 +178,10 @@ export const formatGqlSplit: (arg0: GqlSplit) => ISplit = (gqlSplit) => {
 
 // Should only be called by formatSplit on SplitsClient
 export const protectedFormatSplit = (gqlSplit: ISplit): Split => {
+  const totalOwnership = gqlSplit.recipients.reduce((acc, recipient) => {
+    return acc + recipient.ownership
+  }, BigInt(0))
+
   return {
     type: gqlSplit.type === 'split' ? 'Split' : 'SplitV2',
     address: gqlSplit.address,
@@ -201,16 +205,22 @@ export const protectedFormatSplit = (gqlSplit: ISplit): Split => {
       .sort((a, b) => {
         return a.idx - b.idx
       })
-      .map((gqlRecipient) => formatRecipient(gqlRecipient)),
+      .map((gqlRecipient) => formatRecipient(gqlRecipient, totalOwnership)),
   }
 }
 
-export const formatRecipient = (gqlRecipient: IHolder) => {
+export const formatRecipient = (
+  gqlRecipient: IHolder,
+  totalOwnership: bigint,
+) => {
   return {
     recipient: {
       address: gqlRecipient.address,
     },
     ownership: gqlRecipient.ownership,
-    percentAllocation: fromBigIntToPercent(gqlRecipient.ownership),
+    percentAllocation: fromBigIntToPercent(
+      gqlRecipient.ownership,
+      totalOwnership,
+    ),
   }
 }


### PR DESCRIPTION
https://linear.app/splits/issue/PE-3227/sdk-wrong-scaling-for-ownership-total-and-percent

Make sure we handle arbitrary total allocation in v2 split. I'm going to patch this on top of the current version (i.e. 4.1.1)

Quick code for testing, make sure the percent allocations add up to 100:

```
const client = new SplitsClient({
  apiConfig: {
    apiKey: "key",
  },
});
const dataClient = client.dataClient;

dataClient
  ?.getSplitMetadata({
    chainId: 1,
    splitAddress: "0x2d07Fe97C408Ce0257e48A9D221B00Bf8264d540",
  })
  .then((result) => {
    console.log("GOT IT");
    console.log(result);
  })
  .catch((error) => {
    console.log("OH NO ERROR");
    console.log(error);
  });
```