### PR TITLE
Block number chains

### DIFF
--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "1.0.2-alpha.1",
+  "version": "1.0.2-alpha.2",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "1.0.2-alpha.2",
+  "version": "1.0.2-alpha.3",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "3.0.1",
+  "version": "3.0.2-alpha.0",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "3.0.2-alpha.0",
+  "version": "3.0.2-alpha.1",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "5.0.2-alpha.0",
+  "version": "5.0.2-alpha.1",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "5.0.1",
+  "version": "5.0.2-alpha.0",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/src/client/splitV1.ts
+++ b/packages/splits-sdk/src/client/splitV1.ts
@@ -619,6 +619,7 @@ class SplitV1Transactions extends BaseTransactions {
 
     const split: Split = {
       address: splitAddress,
+      totalOwnership: BigInt(1_000_000),
       recipients,
       distributorFeePercent: fromBigIntToPercent(
         BigInt(createLog.args.distributorFee),

--- a/packages/splits-sdk/src/client/splitV2.ts
+++ b/packages/splits-sdk/src/client/splitV2.ts
@@ -483,8 +483,13 @@ class SplitV2Transactions extends BaseTransactions {
       }
     }
 
+    const totalOwnership = recipients!.reduce((acc, recipient) => {
+      return acc + recipient.ownership
+    }, BigInt(0))
+
     const split: Split = {
       address: splitAddress,
+      totalOwnership,
       recipients: recipients!,
       distributorFeePercent: distributorFeePercent!,
       distributeDirection: type,

--- a/packages/splits-sdk/src/client/splitV2.ts
+++ b/packages/splits-sdk/src/client/splitV2.ts
@@ -466,9 +466,9 @@ class SplitV2Transactions extends BaseTransactions {
 
     if (createLog) type = getSplitType(chainId, createLog.address)
     else {
-      this._requirePublicClient(chainId)
+      const publicClient = this._getPublicClient(chainId)
 
-      const code = await this._publicClient?.getBytecode({
+      const code = await publicClient.getBytecode({
         address: splitAddress,
       })
 

--- a/packages/splits-sdk/src/constants/index.ts
+++ b/packages/splits-sdk/src/constants/index.ts
@@ -256,7 +256,28 @@ export const SPLITS_V2_SUPPORTED_CHAIN_IDS = [
   ChainId.PLUME_TESTNET,
 ]
 
-export const SPLITS_SUBGRAPH_CHAIN_IDS = ALL_CHAIN_IDS.slice()
+// These chains use a different value for block.number than the actual block number
+// for the transaction. This breaks the regular flow in the SDK for the splitV2o1
+// contract. Need to fall back to the regular logs flow for these chains.
+export const INVALID_BLOCK_NUMBER_CHAIN_IDS = [
+  ChainId.ARBITRUM,
+  ChainId.PLUME,
+  ChainId.PLUME_TESTNET,
+]
+export const SPLITS_SUBGRAPH_CHAIN_IDS = [
+  ChainId.MAINNET,
+  ChainId.OPTIMISM,
+  ChainId.BASE,
+  ChainId.ZORA,
+  ChainId.POLYGON,
+  ChainId.ARBITRUM,
+  ChainId.GNOSIS,
+  ChainId.BSC,
+  ChainId.BLAST,
+  ChainId.HOLESKY,
+  ChainId.SEPOLIA,
+  ChainId.BASE_SEPOLIA,
+]
 export const WATERFALL_CHAIN_IDS = ALL_CHAIN_IDS.slice().filter(
   (id) =>
     id !== ChainId.ZORA_SEPOLIA &&

--- a/packages/splits-sdk/src/subgraph/split.ts
+++ b/packages/splits-sdk/src/subgraph/split.ts
@@ -201,6 +201,7 @@ export const protectedFormatSplit = (gqlSplit: ISplit): Split => {
     distributeDirection: gqlSplit.distributeDirection,
     distributionsPaused: gqlSplit.distributionsPaused,
     createdBlock: gqlSplit.createdBlock,
+    totalOwnership,
     recipients: gqlSplit.recipients
       .sort((a, b) => {
         return a.idx - b.idx

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -625,6 +625,7 @@ export type Split = {
   distributorFeePercent: number
   distributionsPaused: boolean
   distributeDirection: 'pull' | 'push'
+  totalOwnership: bigint
   recipients: {
     percentAllocation: number
     ownership: bigint

--- a/packages/splits-sdk/src/utils/requests.ts
+++ b/packages/splits-sdk/src/utils/requests.ts
@@ -4,6 +4,7 @@ import { SplitsPublicClient, SplitV2Type } from '../types'
 import {
   getSplitV2FactoriesStartBlock,
   getSplitV2FactoryAddress,
+  INVALID_BLOCK_NUMBER_CHAIN_IDS,
 } from '../constants'
 import { splitV2FactoryABI } from '../constants/abi/splitV2Factory'
 import { splitMainPolygonAbi, splitV2ABI } from '../constants/abi'
@@ -441,7 +442,10 @@ export const searchLogs = async <
   let createLog: SplitCreatedLogType | undefined = undefined
   let updateLog: SplitUpdatedLogType | undefined = currentUpdateLog
 
-  if (splitV2Version === 'splitV2o1') {
+  if (
+    splitV2Version === 'splitV2o1' &&
+    !INVALID_BLOCK_NUMBER_CHAIN_IDS.includes(publicClient.chain?.id)
+  ) {
     const splitContract = getContract({
       address: formattedSplitAddress,
       abi: splitV2o1Abi,


### PR DESCRIPTION
Updates:
- Update the `SPLITS_SUBGRAPH_CHAIN_IDS` list to be correct
- Fix grabbing the public client for checking the bytecode
- If the chain does not have typical `block.number` usage (as of now just arbitrum and plume), skip the 2o1 logs handling and use the regular logs search/pagination.