### PR TITLE
feat(splits): add ownerAddress to SplitV2 type

### DIFF
--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -302,6 +302,8 @@ export type SplitV2 = {
   totalAllocation: bigint
   paused: boolean
   type: SplitV2Type
+  ownerAddress: Address
+  // Deprecated
   controllerAddress: Address
   creatorAddress: Address
 }

--- a/packages/splits-sdk/src/types.ts
+++ b/packages/splits-sdk/src/types.ts
@@ -303,8 +303,6 @@ export type SplitV2 = {
   paused: boolean
   type: SplitV2Type
   ownerAddress: Address
-  // Deprecated
-  controllerAddress: Address
   creatorAddress: Address
 }
 


### PR DESCRIPTION
I don't see this SplitV2 type being used anywhere internally across the 3 packages we use but clients might be importing the type to store the split configuration. Will mention the breaking change in the release. 

Dropped `controllerAddress` since this is going into a major release so its okay to push through a breaking change.