### PR TITLE
PE-5998 Add Tempo Mainnet support to SDK

### DIFF
--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "2.4.0-alpha.0",
+  "version": "2.4.0-alpha.1",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-kit",
-  "version": "2.3.1",
+  "version": "2.4.0-alpha.0",
   "description": "UI Components for working with 0xSplits contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/splits-kit/src/constants/chains.ts
+++ b/packages/splits-kit/src/constants/chains.ts
@@ -43,6 +43,22 @@ export const tempoTestnet = defineChain({
   testnet: true,
 })
 
+export const tempoMainnet = defineChain({
+  id: 4217,
+  name: 'Tempo',
+  nativeCurrency: {
+    name: 'USD',
+    symbol: 'USD',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc.tempo.xyz'] },
+  },
+  blockExplorers: {
+    default: { name: 'Tempo Explorer', url: 'https://explore.tempo.xyz' },
+  },
+})
+
 export const SupportedChainsList = [
   mainnet,
   polygon,
@@ -64,6 +80,7 @@ export const SupportedChainsList = [
   worldchain,
   plumeMainnet,
   tempoTestnet,
+  tempoMainnet,
   abstract,
   abstractTestnet,
   ronin,
@@ -231,6 +248,13 @@ export const CHAIN_INFO: ChainInfo = {
   },
   [tempoTestnet.id]: {
     label: 'Tempo Testnet',
+    logoUrl: '/networks/ethereum_logo.svg',
+    nativeCurrency: {
+      symbol: 'USD',
+    },
+  },
+  [tempoMainnet.id]: {
+    label: 'Tempo',
     logoUrl: '/networks/ethereum_logo.svg',
     nativeCurrency: {
       symbol: 'USD',

--- a/packages/splits-kit/storybook/constants/chains.ts
+++ b/packages/splits-kit/storybook/constants/chains.ts
@@ -30,6 +30,7 @@ import {
   CHAIN_INFO,
   SupportedChainId,
   tempoTestnet,
+  tempoMainnet,
 } from '../../src/constants/chains'
 
 interface L1StorybookChainInfo {
@@ -180,6 +181,11 @@ export const STORYBOOK_CHAIN_INFO: ChainInfo = {
     ...CHAIN_INFO[tempoTestnet.id],
     viemChain: tempoTestnet,
     rpcUrls: ['https://rpc.moderato.tempo.xyz'],
+  },
+  [tempoMainnet.id]: {
+    ...CHAIN_INFO[tempoMainnet.id],
+    viemChain: tempoMainnet,
+    rpcUrls: ['https://rpc.tempo.xyz'],
   },
   [abstract.id]: {
     ...CHAIN_INFO[abstract.id],

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk-react",
-  "version": "4.3.1",
+  "version": "4.4.0-alpha.0",
   "description": "React wrapper for the 0xSplits SDK",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xsplits/splits-sdk",
-  "version": "6.4.1",
+  "version": "6.5.0-alpha.0",
   "description": "SDK for the 0xSplits protocol",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/splits-sdk/src/constants/index.ts
+++ b/packages/splits-sdk/src/constants/index.ts
@@ -516,13 +516,12 @@ export const CHAIN_INFO: {
     },
     startBlockV2: 1759,
   },
-  // TODO(PE-5998): Replace placeholder start blocks with deployment block.
   [ChainId.TEMPO]: {
-    startBlock: 1,
+    startBlock: 4711932,
     nativeCurrency: {
       symbol: 'USD',
     },
-    startBlockV2: 1,
+    startBlockV2: 4711932,
   },
   [ChainId.TEMPO_TESTNET]: {
     startBlock: 80320,

--- a/packages/splits-sdk/src/constants/index.ts
+++ b/packages/splits-sdk/src/constants/index.ts
@@ -209,6 +209,7 @@ export enum ChainId {
   WORLDCHAIN = 480,
   PLUME = 98866,
   PLUME_TESTNET = 98867,
+  TEMPO = 4217,
   TEMPO_TESTNET = 42431,
   ABSTRACT = 2741,
   ABSTRACT_SEPOLIA = 11124,
@@ -235,7 +236,7 @@ export const BLAST_CHAIN_IDS = [ChainId.BLAST]
 export const SHAPE_CHAIN_IDS = [ChainId.SHAPE]
 export const WORLD_CHAIN_IDS = [ChainId.WORLDCHAIN]
 export const PLUME_CHAIN_IDS = [ChainId.PLUME, ChainId.PLUME_TESTNET]
-export const TEMPO_CHAIN_IDS = [ChainId.TEMPO_TESTNET]
+export const TEMPO_CHAIN_IDS = [ChainId.TEMPO, ChainId.TEMPO_TESTNET]
 export const ABSTRACT_CHAIN_IDS = [ChainId.ABSTRACT, ChainId.ABSTRACT_SEPOLIA]
 export const RONIN_CHAIN_IDS = [ChainId.RONIN, ChainId.SAIGON]
 export const CELO_CHAIN_IDS = [ChainId.CELO]
@@ -296,6 +297,7 @@ export const SPLITS_V2_SUPPORTED_CHAIN_IDS = [
   ChainId.WORLDCHAIN,
   ChainId.PLUME,
   ChainId.PLUME_TESTNET,
+  ChainId.TEMPO,
   ChainId.TEMPO_TESTNET,
   ChainId.ABSTRACT,
   ChainId.ABSTRACT_SEPOLIA,
@@ -513,6 +515,14 @@ export const CHAIN_INFO: {
       symbol: 'PLUME',
     },
     startBlockV2: 1759,
+  },
+  // TODO(PE-5998): Replace placeholder start blocks with deployment block.
+  [ChainId.TEMPO]: {
+    startBlock: 1,
+    nativeCurrency: {
+      symbol: 'USD',
+    },
+    startBlockV2: 1,
   },
   [ChainId.TEMPO_TESTNET]: {
     startBlock: 80320,


### PR DESCRIPTION
## Summary
- add Tempo Mainnet chain id (`4217`) to SDK chain constants
- include Tempo Mainnet in `TEMPO_CHAIN_IDS` and `SPLITS_V2_SUPPORTED_CHAIN_IDS`
- add `CHAIN_INFO` entry for Tempo Mainnet with USD native symbol and placeholder start blocks

## Why
Tempo Mainnet contracts are deployed and SDK chain support is needed before Splits Lite rollout.

## How has this been tested?
Manual validation steps:
1. Initialize `SplitsClient` with `chainId: 4217` and a Tempo Mainnet public client.
2. Confirm `splitV2` and `warehouse` read/write methods no longer fail chain-id validation.
3. Confirm provider-based metadata/balance fetches use Tempo Mainnet chain info and start blocks.

Notes:
- Repository check commands were executed, but `pnpm typecheck` is not defined in this repo and `pnpm test` currently fails in this workspace due an existing viem type-resolution issue (`Call` export mismatch) unrelated to this constants change.
