### PR TITLE
Update docs.splits.org links to splits.org/protocol/docs

### DIFF
--- a/packages/splits-kit/README.md
+++ b/packages/splits-kit/README.md
@@ -13,6 +13,6 @@ npm install @0xsplits/splits-kit
 
 ## Documentation
 
-Detailed documentation for the SDK can be found [here](https://docs.splits.org/splits-kit)
+Detailed documentation for the SDK can be found [here](https://splits.org/protocol/docs/splits-kit)
 
 Live Storybook demo can be found [here](https://kit.splits.org)

--- a/packages/splits-kit/package.json
+++ b/packages/splits-kit/package.json
@@ -41,7 +41,7 @@
   "bugs": {
     "url": "https://github.com/0xSplits/splits-sdk/issues"
   },
-  "homepage": "https://docs.splits.org/sdk-info/overview",
+  "homepage": "https://splits.org/protocol/docs/sdk-info/overview",
   "dependencies": {
     "@0xsplits/splits-sdk": "workspace:*",
     "@0xsplits/splits-sdk-react": "workspace:*",

--- a/packages/splits-kit/src/components/CreateSplit/CreateSplitForm.tsx
+++ b/packages/splits-kit/src/components/CreateSplit/CreateSplitForm.tsx
@@ -179,7 +179,7 @@ const CreateSplitForm = ({
     connectedAddress,
   )}`
 
-  const docsLink = `https://docs.splits.org/core/split${
+  const docsLink = `https://splits.org/protocol/docs/core/split${
     type === 'v1' ? '' : '-v2'
   }`
 

--- a/packages/splits-kit/storybook/stories/Introduction.stories.tsx
+++ b/packages/splits-kit/storybook/stories/Introduction.stories.tsx
@@ -12,7 +12,7 @@ const Components = () => {
         <a
           className="underline"
           target="_blank"
-          href="https://docs.splits.org/splits-kit"
+          href="https://splits.org/protocol/docs/splits-kit"
         >
           docs
         </a>

--- a/packages/splits-sdk-react/README.md
+++ b/packages/splits-sdk-react/README.md
@@ -17,7 +17,7 @@ npm install @0xsplits/splits-sdk-react
 
 ## Documentation
 
-Detailed documentation for the SDK can be found [here](https://docs.splits.org/react)
+Detailed documentation for the SDK can be found [here](https://splits.org/protocol/docs/react)
 
 
 ### Viem vs Ethers
@@ -31,4 +31,4 @@ yarn add @0xsplits/splits-sdk-react@0
 npm install @0xsplits/splits-sdk-react@0
 ```
 
-Documentation for the old Ethers version can be found [here](https://docs.splits.org/react-ethers)
+Documentation for the old Ethers version can be found [here](https://splits.org/protocol/docs/react-ethers)

--- a/packages/splits-sdk-react/package.json
+++ b/packages/splits-sdk-react/package.json
@@ -38,7 +38,7 @@
   "bugs": {
     "url": "https://github.com/0xSplits/splits-sdk/issues"
   },
-  "homepage": "https://docs.splits.org/sdk",
+  "homepage": "https://splits.org/protocol/docs/sdk",
   "dependencies": {
     "@0xsplits/splits-sdk": "workspace:*"
   },

--- a/packages/splits-sdk/README.md
+++ b/packages/splits-sdk/README.md
@@ -12,7 +12,7 @@ npm install @0xsplits/splits-sdk
 
 ## Documentation
 
-Detailed documentation for the SDK can be found [here](https://docs.splits.org/sdk)
+Detailed documentation for the SDK can be found [here](https://splits.org/protocol/docs/sdk)
 
 ### Viem vs Ethers
 
@@ -25,4 +25,4 @@ yarn add @0xsplits/splits-sdk@2
 npm install @0xsplits/splits-sdk@2
 ```
 
-Documentation for the old Ethers version can be found [here](https://docs.splits.org/sdk-ethers)
+Documentation for the old Ethers version can be found [here](https://splits.org/protocol/docs/sdk-ethers)

--- a/packages/splits-sdk/package.json
+++ b/packages/splits-sdk/package.json
@@ -58,7 +58,7 @@
   "bugs": {
     "url": "https://github.com/0xSplits/splits-sdk/issues"
   },
-  "homepage": "https://docs.splits.org/sdk",
+  "homepage": "https://splits.org/protocol/docs/sdk",
   "peerDependencies": {
     "viem": "^2.0.0"
   },


### PR DESCRIPTION
Docs have moved from `docs.splits.org` to `https://splits.org/protocol/docs` as part of the Teams rebrand. This sweeps the remaining references to the old domain in this repo.

Mechanical find-and-replace of `docs.splits.org` → `splits.org/protocol/docs`; paths and anchors preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)